### PR TITLE
Fix toPrecision

### DIFF
--- a/src/Decimal128.mts
+++ b/src/Decimal128.mts
@@ -461,13 +461,13 @@ export class Decimal128 {
             return this.toString();
         }
 
-        let n = opts.digits;
+        let precision = opts.digits;
 
-        if (n <= 0) {
+        if (precision <= 0) {
             throw new RangeError("Argument must be positive");
         }
 
-        if (!Number.isInteger(n)) {
+        if (!Number.isInteger(precision)) {
             throw new RangeError("Argument must be an integer");
         }
 
@@ -481,23 +481,48 @@ export class Decimal128 {
 
         let s = this.abs().emitDecimal();
 
-        let [lhs, rhs] = s.split(/[.]/);
         let p = this.isNegative() ? "-" : "";
 
-        if (n < lhs.length) {
-            if (lhs.length === n) {
-                return p + lhs;
+        if (this.isZero()) {
+            if (precision === 1) {
+                return p + "0";
             }
-
-            return p + s.substring(0, n) + "e+" + `${lhs.length - n}`;
+            return p + "0." + "0".repeat(precision - 1)
         }
 
-        if (n <= lhs.length + rhs.length) {
-            let rounded = this.round(n - lhs.length);
-            return rounded.emitDecimal();
+        const { q, n } = findLargestQ(s);
+        const coefficient = n.replace(/^0+/, "");
+        const numDigits = coefficient.length;
+
+        if (numDigits < precision) {
+            const additionalZeroes = "0".repeat(precision - numDigits);
+
+            // if d is an integer
+            if (q >= 0) {
+                return coefficient + "." + additionalZeroes;
+            } else {
+                return p + s + additionalZeroes;
+            }
         }
 
-        return p + lhs + "." + rhs + "0".repeat(n - lhs.length - rhs.length);
+        if (numDigits === precision) {
+            return this.clone().toString();
+        }
+
+        const exp = q + numDigits;
+
+        const roundedAndScaled = new Decimal128(`${p}0.${coefficient}`).round(precision).scale10(exp);
+
+        if (roundedAndScaled.quantum() < 0) { 
+            return roundedAndScaled.emitDecimal();
+        }
+
+        const str = roundedAndScaled.abs().toString();
+        if (str.length === precision) {
+            return p + str;
+        }
+
+        return p + str.substring(0, precision) + `e+${str.length - precision}`;
     }
 
     toExponential(opts?: { digits?: number }): string {
@@ -1147,3 +1172,27 @@ export class Decimal128 {
 Decimal128.prototype.valueOf = function () {
     throw TypeError("Decimal128.prototype.valueOf throws unconditionally");
 };
+
+const trimZeroR = (s: string) => s.replace(/0+$/, "");
+const trimZeroL = (s: string) => s.replace(/^0+/, "");
+function findLargestQ(d: string) {
+    const [lhs = "", rhs = ""] = d.split(".");
+    const lhsLen = trimZeroL(lhs).length;
+
+    const rhsRTrimmed = trimZeroR(rhs);
+    const rhsLen = rhsRTrimmed.length;
+
+    if (rhsLen === 0) {
+      const lhsRTrimmed = trimZeroR(lhs);
+      const q = lhsLen - lhsRTrimmed.length;
+      return {
+        q,
+        n: lhsRTrimmed,
+      };
+    }
+    
+    return {
+        q: -rhsLen,
+        n: lhs + rhs,
+    };
+}

--- a/src/Decimal128.mts
+++ b/src/Decimal128.mts
@@ -489,7 +489,7 @@ export class Decimal128 {
                 return p + lhs;
             }
 
-            return p + s.substring(0, n) + "e+" + `${lhs.length - n + 1}`;
+            return p + s.substring(0, n) + "e+" + `${lhs.length - n}`;
         }
 
         if (n <= lhs.length + rhs.length) {

--- a/tests/Decimal128/toprecision.test.js
+++ b/tests/Decimal128/toprecision.test.js
@@ -72,7 +72,7 @@ describe("zero", () => {
         ${"positive zero"}                            | ${" 0"}    | ${NoArgument}     | ${" 0"}
         ${"negative zero"}                            | ${"-0"}    | ${NoArgument}     | ${"-0"}
         ${"zero point zero gets canonicalized"}       | ${" 0.0"}  | ${NoArgument}     | ${" 0"}
-        ${"zero point zero, one significant digit"}   | ${" 0.0"}  | ${{ digits: 1 }}  | ${" 0.0"}
+        ${"zero point zero, one significant digit"}   | ${" 0.0"}  | ${{ digits: 1 }}  | ${" 0"}
     `("$name", ({ input, arg, output }) => {
         const d = new Decimal128(input.trim());
         const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);
@@ -95,5 +95,196 @@ describe("infinity", () => {
         const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);
         const o = output.trim();
         expect(s).toStrictEqual(o);
+    });
+});
+
+describe("tests", () => {
+    describe("with integer output", () => {
+        test.each`
+            input      | digits     | output
+            ${" 0.0"}  |  ${1}      |  ${"0"}
+            ${" 1.4"}  |  ${1}      |  ${"1"}
+            ${" 1.5"}  |  ${1}      |  ${"2"}  // halfEven rounded up to even
+            ${" 1.6"}  |  ${1}      |  ${"2"}
+            ${" 2.4"}  |  ${1}      |  ${"2"}
+            ${" 2.5"}  |  ${1}      |  ${"2"}  // halfEven rounded down to even
+            ${" 2.6"}  |  ${1}      |  ${"3"}
+            ${"-0.0"}  |  ${1}      | ${"-0"}
+            ${"-1.4"}  |  ${1}      | ${"-1"}
+            ${"-1.5"}  |  ${1}      | ${"-2"}  // halfEven rounded up to even
+            ${"-1.6"}  |  ${1}      | ${"-2"}
+            ${"-2.4"}  |  ${1}      | ${"-2"}
+            ${"-2.5"}  |  ${1}      | ${"-2"}  // halfEven rounded down to even
+            ${"-2.6"}  |  ${1}      | ${"-3"}
+        `("$input precision($digits) = $output", ({ input, digits, output }) => {
+            const s = new Decimal128(input.trim()).toPrecision({ digits });
+            expect(s).toStrictEqual(output.trim());
+        });
+    });
+    describe("with decimal output", () => {
+        test.each`
+            input      | digits     | output
+            ${" 0.14"} |  ${1}      |  ${"0.1"}
+            ${" 0.15"} |  ${1}      |  ${"0.2"}  // halfEven rounded up to even
+            ${" 0.16"} |  ${1}      |  ${"0.2"}
+            ${" 0.24"} |  ${1}      |  ${"0.2"}
+            ${" 0.25"} |  ${1}      |  ${"0.2"}  // halfEven rounded down to even
+            ${" 0.26"} |  ${1}      |  ${"0.3"}
+            ${"-0.14"} |  ${1}      | ${"-0.1"}
+            ${"-0.15"} |  ${1}      | ${"-0.2"}  // halfEven rounded up to even
+            ${"-0.16"} |  ${1}      | ${"-0.2"}
+            ${"-0.24"} |  ${1}      | ${"-0.2"}
+            ${"-0.25"} |  ${1}      | ${"-0.2"}  // halfEven rounded down to even
+            ${"-0.26"} |  ${1}      | ${"-0.3"}
+        `("$input precision($digits) = $output", ({ input, digits, output }) => {
+            const s = new Decimal128(input.trim()).toPrecision({ digits });
+            expect(s).toStrictEqual(output.trim());
+        });
+    });
+    describe("with exponent output", () => {
+        test.each`
+            input      | digits     | output
+            ${" 1014"} |  ${3}      |  ${"101e+1"}  
+            ${" 1015"} |  ${3}      |  ${"102e+1"}  // halfEven rounded up to even
+            ${" 1016"} |  ${3}      |  ${"102e+1"}
+            ${" 1024"} |  ${3}      |  ${"102e+1"}  
+            ${" 1025"} |  ${3}      |  ${"102e+1"}  // halfEven rounded down to even
+            ${" 1026"} |  ${3}      |  ${"103e+1"}
+            ${"-1014"} |  ${3}      | ${"-101e+1"}  
+            ${"-1015"} |  ${3}      | ${"-102e+1"}  // halfEven rounded up to even
+            ${"-1016"} |  ${3}      | ${"-102e+1"}
+            ${"-1024"} |  ${3}      | ${"-102e+1"}  
+            ${"-1025"} |  ${3}      | ${"-102e+1"}  // halfEven rounded down to even
+            ${"-1026"} |  ${3}      | ${"-103e+1"}
+        `("$input precision($digits) = $output", ({ input, digits, output }) => {
+            const s = new Decimal128(input.trim()).toPrecision({ digits });
+            expect(s).toStrictEqual(output.trim());
+        });
+    });
+    describe("with large positive exponent output", () => {
+        const d = new Decimal128("1002500000_0005500000_0008500000_0001");
+        //                       "1234567890_1234567890_1234567890_1234"
+
+        describe("positive", () => {
+            test.each`
+                digits     | output
+                 ${3}      |  ${"100e+31"}
+                 ${4}      |  ${"1002e+30"}
+                 ${5}      |  ${"10025e+29"}
+                ${13}      |  ${"1002500000000e+21"}
+                ${14}      |  ${"10025000000006e+20"}
+                ${15}      |  ${"100250000000055e+19"}
+                ${23}      |  ${"10025000000005500000001e+11"}
+                ${24}      |  ${"100250000000055000000008e+10"}
+                ${25}      |  ${"1002500000000550000000085e+9"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = d.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
+        describe("negative", () => {
+            const negD = d.negate();
+            test.each`
+                digits     | output
+                 ${3}      |  ${"-100e+31"}
+                 ${4}      |  ${"-1002e+30"}
+                 ${5}      |  ${"-10025e+29"}
+                ${13}      |  ${"-1002500000000e+21"}
+                ${14}      |  ${"-10025000000006e+20"}
+                ${15}      |  ${"-100250000000055e+19"}
+                ${23}      |  ${"-10025000000005500000001e+11"}
+                ${24}      |  ${"-100250000000055000000008e+10"}
+                ${25}      |  ${"-1002500000000550000000085e+9"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = negD.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
+    });
+
+    describe("with large negative exponent output", () => {
+        const d = new Decimal128("0.1002500000_0005500000_0008500000_0001");
+        //                       "0.1234567890_1234567890_1234567890_1234"
+
+        describe("positive", () => {
+            test.each`
+                digits     | output
+                 ${3}      |  ${"0.100"}
+                 ${4}      |  ${"0.1002"}
+                 ${5}      |  ${"0.10025"}
+                ${13}      |  ${"0.1002500000000"}
+                ${14}      |  ${"0.10025000000006"}
+                ${15}      |  ${"0.100250000000055"}
+                ${23}      |  ${"0.10025000000005500000001"}
+                ${24}      |  ${"0.100250000000055000000008"}
+                ${25}      |  ${"0.1002500000000550000000085"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = d.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
+        describe("negative", () => {
+            const negD = d.negate();
+            test.each`
+                digits     | output
+                 ${3}      |  ${"-0.100"}
+                 ${4}      |  ${"-0.1002"}
+                 ${5}      |  ${"-0.10025"}
+                ${13}      |  ${"-0.1002500000000"}
+                ${14}      |  ${"-0.10025000000006"}
+                ${15}      |  ${"-0.100250000000055"}
+                ${23}      |  ${"-0.10025000000005500000001"}
+                ${24}      |  ${"-0.100250000000055000000008"}
+                ${25}      |  ${"-0.1002500000000550000000085"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = negD.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
+    });
+
+    describe("with large negative exponent output with leading zero in decimal portion", () => {
+        const d = new Decimal128("0.000_1002500000_0005500000_0008500000_0001");
+        //                       "0.000_1234567890_1234567890_1234567890_1234"
+
+        describe("positive", () => {
+            test.each`
+                digits     | output
+                 ${1}      |  ${"0.0001"}
+                 ${2}      |  ${"0.00010"}
+                 ${3}      |  ${"0.000100"}
+                 ${4}      |  ${"0.0001002"}
+                 ${5}      |  ${"0.00010025"}
+                ${13}      |  ${"0.0001002500000000"}
+                ${14}      |  ${"0.00010025000000006"}
+                ${15}      |  ${"0.000100250000000055"}
+                ${23}      |  ${"0.00010025000000005500000001"}
+                ${24}      |  ${"0.000100250000000055000000008"}
+                ${25}      |  ${"0.0001002500000000550000000085"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = d.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
+        describe("negative", () => {
+            const negD = d.negate();
+            test.each`
+                digits     | output
+                 ${1}      |  ${"-0.0001"}
+                 ${2}      |  ${"-0.00010"}
+                 ${3}      |  ${"-0.000100"}
+                 ${4}      |  ${"-0.0001002"}
+                 ${5}      |  ${"-0.00010025"}
+                ${13}      |  ${"-0.0001002500000000"}
+                ${14}      |  ${"-0.00010025000000006"}
+                ${15}      |  ${"-0.000100250000000055"}
+                ${23}      |  ${"-0.00010025000000005500000001"}
+                ${24}      |  ${"-0.000100250000000055000000008"}
+                ${25}      |  ${"-0.0001002500000000550000000085"}
+            `("precision($digits) = $output", ({ digits, output }) => {
+                const s = negD.toPrecision({ digits });
+                expect(s).toStrictEqual(output.trim());
+            });
+        });
     });
 });

--- a/tests/Decimal128/toprecision.test.js
+++ b/tests/Decimal128/toprecision.test.js
@@ -1,78 +1,58 @@
 import { Decimal128 } from "../../src/Decimal128.mjs";
-import { expectDecimal128 } from "./util.js";
+
+const NoArgument = Symbol();
 
 describe("toPrecision", () => {
     let d = new Decimal128("123.456");
-    test("simple example, no arguments", () => {
-        expect(d.toPrecision()).toStrictEqual("123.456");
+
+    describe("simple example", () => {
+
+        describe.each([
+            { sign: "positive", input: d, },
+            { sign: "negative", input: d.negate(), },
+        ])("$sign", ({ sign, input }) => {
+            test.each`
+                name                                                                                     | arg               | output
+                ${"no arguments"}                                                                        | ${NoArgument}     | ${"123.456"}
+                ${"argument is greater than total number of significant digits"}                         | ${{ digits: 7 }}  | ${"123.4560"}
+                ${"argument is equal to number of significant digits"}                                   | ${{ digits: 6 }}  | ${"123.456"}
+                ${"argument less than number of significant digits, rounded needed"}                     | ${{ digits: 5 }}  | ${"123.46"}
+                ${"argument less than number of significant digits, rounded does not change last digit"} | ${{ digits: 4 }}  | ${"123.4"}
+                ${"argument equals number of integer digits"}                                            | ${{ digits: 3 }}  | ${"123"}
+                ${"argument less than number of integer digits"}                                         | ${{ digits: 2 }}  | ${"12e+2"}
+                ${"single digit requested"}                                                              | ${{ digits: 1 }}  | ${"1e+3"}
+            `("$name", ({ arg, output }) => {
+                const d = input;
+                const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);
+                const o = sign === "positive" ? output : `-${output}`;
+                expect(s).toStrictEqual(o);
+            });
+
+            test("zero digits requested", () => {
+                expect(() => input.toPrecision({ digits: 0 })).toThrow(RangeError);
+            });
+        });
     });
-    test("simple example, negative, no arguments", () => {
-        expect(d.negate().toPrecision()).toStrictEqual("-123.456");
-    });
-    test("simple example, argument is greater than total number of significant digits", () => {
-        expect(d.toPrecision({ digits: 7 })).toStrictEqual("123.4560");
-    });
-    test("simple example, negative, argument is greater than total number of significant digits", () => {
-        expect(d.negate().toPrecision({ digits: 7 })).toStrictEqual(
-            "-123.4560"
-        );
-    });
-    test("simple example, argument is equal to number of significant digits", () => {
-        expect(d.toPrecision({ digits: 6 })).toStrictEqual("123.456");
-    });
-    test("simple example, negative, argument is equal to number of significant digits", () => {
-        expect(d.negate().toPrecision({ digits: 6 })).toStrictEqual("-123.456");
-    });
-    test("simple example, argument less than number of significant digits, rounded needed", () => {
-        expect(d.toPrecision({ digits: 5 })).toStrictEqual("123.46");
-    });
-    test("simple example, negative, argument less than number of significant digits, rounded needed", () => {
-        expect(d.negate().toPrecision({ digits: 5 })).toStrictEqual("-123.46");
-    });
-    test("simple example, argument less than number of significant digits, rounded does not change last digit", () => {
-        expect(d.toPrecision({ digits: 4 })).toStrictEqual("123.4");
-    });
-    test("simple example, negative, argument less than number of significant digits, rounded does not change last digit", () => {
-        expect(d.negate().toPrecision({ digits: 4 })).toStrictEqual("-123.4");
-    });
-    test("simple example, argument equals number of integer digits", () => {
-        expect(d.toPrecision({ digits: 3 })).toStrictEqual("123");
-    });
-    test("simple example, negative, argument equals number of integer digits", () => {
-        expect(d.negate().toPrecision({ digits: 3 })).toStrictEqual("-123");
-    });
-    test("simple example, argument less than number of integer digits", () => {
-        expect(d.toPrecision({ digits: 2 })).toStrictEqual("12e+2");
-    });
-    test("simple example, negative, argument less than number of integer digits", () => {
-        expect(d.negate().toPrecision({ digits: 2 })).toStrictEqual("-12e+2");
-    });
-    test("simple example, single digit requested", () => {
-        expect(d.toPrecision({ digits: 1 })).toStrictEqual("1e+3");
-    });
-    test("simple example, negative, single digit requested", () => {
-        expect(d.negate().toPrecision({ digits: 1 })).toStrictEqual("-1e+3");
-    });
-    test("simple example, zero digits requested", () => {
-        expect(() => d.toPrecision({ digits: 0 })).toThrow(RangeError);
-    });
-    test("non-object argument throws", () => {
-        expect(() => d.toPrecision("whatever")).toThrow(TypeError);
-    });
-    test("object argument given, but has weird property", () => {
-        expect(d.toPrecision({ foo: "bar" }).toString()).toStrictEqual(
-            "123.456"
-        );
-    });
-    test("non-integer number of digits requested", () => {
-        expect(() => d.toPrecision({ digits: 1.72 }).toString()).toThrow(
-            RangeError
-        );
-    });
-    test("negative integer number of digits requested", () => {
-        expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
-            RangeError
-        );
+
+    describe("", () => {
+        test("non-object argument throws", () => {
+            expect(() => d.toPrecision("whatever")).toThrow(TypeError);
+        });
+        test("object argument given, but has weird property", () => {
+            expect(d.toPrecision({ foo: "bar" }).toString()).toStrictEqual(
+                "123.456"
+            );
+        });
+        test("non-integer number of digits requested", () => {
+            expect(() => d.toPrecision({ digits: 1.72 }).toString()).toThrow(
+                RangeError
+            );
+        });
+        test("negative integer number of digits requested", () => {
+            expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
+                RangeError
+            );
+        });
     });
 });
 
@@ -87,35 +67,33 @@ describe("NaN", () => {
 });
 
 describe("zero", () => {
-    test("positive zero", () => {
-        expect(new Decimal128("0").toPrecision()).toStrictEqual("0");
-    });
-    test("negative zero", () => {
-        expect(new Decimal128("-0").toPrecision()).toStrictEqual("-0");
-    });
-    test("zero point zero gets canonicalized", () => {
-        expect(new Decimal128("0.0").toPrecision()).toStrictEqual("0");
-    });
-    test("zero point zero, one significant digit", () => {
-        expect(new Decimal128("0.0").toPrecision({ digits: 1 })).toStrictEqual(
-            "0.0"
-        );
+    test.each`
+        name                                          | input      | arg               | output
+        ${"positive zero"}                            | ${" 0"}    | ${NoArgument}     | ${" 0"}
+        ${"negative zero"}                            | ${"-0"}    | ${NoArgument}     | ${"-0"}
+        ${"zero point zero gets canonicalized"}       | ${" 0.0"}  | ${NoArgument}     | ${" 0"}
+        ${"zero point zero, one significant digit"}   | ${" 0.0"}  | ${{ digits: 1 }}  | ${" 0.0"}
+    `("$name", ({ input, arg, output }) => {
+        const d = new Decimal128(input.trim());
+        const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);
+        const o = output.trim();
+        expect(s).toStrictEqual(o);
     });
 });
 
 describe("infinity", () => {
     let posInf = new Decimal128("Infinity");
     let negInf = new Decimal128("-Infinity");
-    test("positive infinity", () => {
-        expect(posInf.toPrecision()).toStrictEqual("Infinity");
-    });
-    test("positive infinity, digits requested", () => {
-        expect(posInf.toPrecision({ digits: 42 })).toStrictEqual("Infinity");
-    });
-    test("negative infinity", () => {
-        expect(negInf.toPrecision()).toStrictEqual("-Infinity");
-    });
-    test("negative infinity, digits requested", () => {
-        expect(negInf.toPrecision({ digits: 42 })).toStrictEqual("-Infinity");
+
+    test.each`
+        name                                          | input      | arg                | output
+        ${"positive infinity"}                        | ${posInf}  | ${NoArgument}      | ${" Infinity"}
+        ${"positive infinity, digits requested"}      | ${posInf}  | ${{ digits: 42 }}  | ${" Infinity"}
+        ${"negative infinity"}                        | ${negInf}  | ${NoArgument}      | ${"-Infinity"}
+        ${"negative infinity, digits requested"}      | ${negInf}  | ${{ digits: 42 }}  | ${"-Infinity"}
+    `("$name", ({ input: d, arg, output }) => {
+        const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);
+        const o = output.trim();
+        expect(s).toStrictEqual(o);
     });
 });

--- a/tests/Decimal128/toprecision.test.js
+++ b/tests/Decimal128/toprecision.test.js
@@ -19,8 +19,8 @@ describe("toPrecision", () => {
                 ${"argument less than number of significant digits, rounded needed"}                     | ${{ digits: 5 }}  | ${"123.46"}
                 ${"argument less than number of significant digits, rounded does not change last digit"} | ${{ digits: 4 }}  | ${"123.4"}
                 ${"argument equals number of integer digits"}                                            | ${{ digits: 3 }}  | ${"123"}
-                ${"argument less than number of integer digits"}                                         | ${{ digits: 2 }}  | ${"12e+2"}
-                ${"single digit requested"}                                                              | ${{ digits: 1 }}  | ${"1e+3"}
+                ${"argument less than number of integer digits"}                                         | ${{ digits: 2 }}  | ${"12e+1"}
+                ${"single digit requested"}                                                              | ${{ digits: 1 }}  | ${"1e+2"}
             `("$name", ({ arg, output }) => {
                 const d = input;
                 const s = arg === NoArgument ? d.toPrecision() : d.toPrecision(arg);


### PR DESCRIPTION
> Moved from jessealama/decimal128#128
> commits from jessealama/decimal128#128 are rebased onto the main branch of this repository

## Summary

1. Add more tests for `toPrecision`, implement `toPrecision` according to specification
2. Change to existing test:
    Given | Before | After |
    -- | -- | -- |
    `new Decimal128("123.456").toPrecision({ digits: 2 })` | `"12e+2"` | `"12e+1"`
    `new Decimal128("0.0").toPrecision({ digits: 1 })` | `"0.0"` | `"0"`
3. implement `toPrecision` closer to specification.
    some variables are renamed and created to match the text in the spec


## Related to

https://github.com/jessealama/proposal-decimal-polyfill/issues/15

## How is this tested?

See updated tests for `toPrecision`

![image](https://github.com/user-attachments/assets/97d00c69-04e8-431d-8805-7ce03f981502)
