### PR TITLE
fix: fix TypeError when second argument is zero

### DIFF
--- a/src/Decimal128.mts
+++ b/src/Decimal128.mts
@@ -634,6 +634,13 @@ export class Decimal128 {
 
             return x.isNegative() ? 1 : -1;
         }
+        if (x.isZero()) {
+            if (this.isZero()) {
+                return 0;
+            }
+
+            return this.isNegative() ? -1 : 1;
+        }
 
         let ourCohort = this.cohort() as Rational;
         let theirCohort = x.cohort() as Rational;

--- a/tests/Decimal128/cmp.test.js
+++ b/tests/Decimal128/cmp.test.js
@@ -151,6 +151,18 @@ describe("zero", () => {
     test("compare zero to negative", () => {
         expect(zero.cmp(one.negate())).toStrictEqual(1);
     });
+    test("compare positive to zero", () => {
+        expect(one.cmp(zero)).toStrictEqual(1);
+    });
+    test("compare negative to zero", () => {
+        expect(one.negate().cmp(zero)).toStrictEqual(-1);
+    });
+    test("compare positive to negative zero", () => {
+        expect(one.cmp(zero)).toStrictEqual(1);
+    });
+    test("compare negative to negative zero", () => {
+        expect(one.negate().cmp(zero)).toStrictEqual(-1);
+    });
 });
 
 describe("normalization", () => {


### PR DESCRIPTION
## Summary

handle crash using `cmp` when right hand side is zero


## Related issue

this should close #17 

## How is this tested?

New tests are added with rhs as zero

![image](https://github.com/user-attachments/assets/2d6fd667-a1f0-48d8-81ab-ecb049224be5)
