### PR TITLE
Bundle Dependabot updates into grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,16 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          npm-dependencies:
+              patterns:
+                  - "*"
 
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"


### PR DESCRIPTION
Adds a catch-all group per ecosystem so weekly updates land as one npm PR and one github-actions PR, instead of one PR per dependency.