### PR TITLE
Fix NaN.isFinite() returning true

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -882,6 +882,7 @@ export class Decimal {
 
         if (data === "NaN") {
             this._isNaN = true;
+            this._isFinite = false;
         } else if (data === "Infinity") {
             this._isFinite = false;
         } else if (data === "-Infinity") {

--- a/tests/Decimal/equals.test.js
+++ b/tests/Decimal/equals.test.js
@@ -59,6 +59,16 @@ describe("equals", () => {
             test("NaN equals number is false", () => {
                 expect(nan.equals(one)).toStrictEqual(false);
             });
+            test("NaN equals positive infinity is false", () => {
+                expect(nan.equals(new Decimal("Infinity"))).toStrictEqual(
+                    false
+                );
+            });
+            test("positive infinity equals NaN is false", () => {
+                expect(new Decimal("Infinity").equals(nan)).toStrictEqual(
+                    false
+                );
+            });
         });
         describe("minus zero", () => {
             test("left hand", () => {

--- a/tests/Decimal/isfinite.test.js
+++ b/tests/Decimal/isfinite.test.js
@@ -1,0 +1,22 @@
+import { Decimal } from "../../src/Decimal.mjs";
+
+describe("isFinite", () => {
+    test("42", () => {
+        expect(new Decimal("42").isFinite()).toStrictEqual(true);
+    });
+    test("0", () => {
+        expect(new Decimal("0").isFinite()).toStrictEqual(true);
+    });
+    test("-0", () => {
+        expect(new Decimal("-0").isFinite()).toStrictEqual(true);
+    });
+    test("Infinity", () => {
+        expect(new Decimal("Infinity").isFinite()).toStrictEqual(false);
+    });
+    test("-Infinity", () => {
+        expect(new Decimal("-Infinity").isFinite()).toStrictEqual(false);
+    });
+    test("NaN", () => {
+        expect(new Decimal("NaN").isFinite()).toStrictEqual(false);
+    });
+});

--- a/tests/Decimal/isnormal.test.js
+++ b/tests/Decimal/isnormal.test.js
@@ -31,5 +31,8 @@ describe("isNormal", () => {
         test("simple number with exponent beyond limit", () => {
             expect(new Decimal("42E-6145").isNormal()).toStrictEqual(false);
         });
+        test("number with exponent at upper limit is normal", () => {
+            expect(new Decimal("1E+6144").isNormal()).toStrictEqual(true);
+        });
     });
 });


### PR DESCRIPTION
StrykerJS surfaced a surviving mutant in `equals()` that, when fixing, pointed out a real bug: the constructor set `_isNaN` for `NaN` but never set `_isFinite = false`, so `NaN.isFinite()` incorrectly returned `true`.

We also add a new `isFinite` test file (it had none) and add tests for `NaN` vs `+Infinity` in `equals()` and for `isNormal()` at the upper exponent boundary. This kills a couple of surviving mutants.