### PR TITLE
Add error message assertions in `isNormal()` throw tests

### DIFF
--- a/tests/Decimal/isnormal.test.js
+++ b/tests/Decimal/isnormal.test.js
@@ -4,6 +4,9 @@ describe("isNormal", () => {
     describe("NaN", () => {
         test("throws", () => {
             expect(() => new Decimal("NaN").isNormal()).toThrow(RangeError);
+            expect(() => new Decimal("NaN").isNormal()).toThrow(
+                "Cannot determine whether NaN is normal"
+            );
         });
     });
     describe("infinity", () => {
@@ -11,10 +14,16 @@ describe("isNormal", () => {
             expect(() => new Decimal("Infinity").isNormal()).toThrow(
                 RangeError
             );
+            expect(() => new Decimal("Infinity").isNormal()).toThrow(
+                "Only finite numbers can be said to be normal or not"
+            );
         });
         test("negative throws", () => {
             expect(() => new Decimal("-Infinity").isNormal()).toThrow(
                 RangeError
+            );
+            expect(() => new Decimal("-Infinity").isNormal()).toThrow(
+                "Only finite numbers can be said to be normal or not"
             );
         });
     });
@@ -24,6 +33,9 @@ describe("isNormal", () => {
         });
         test("zero is not normal", () => {
             expect(() => new Decimal("0").isNormal()).toThrow(RangeError);
+            expect(() => new Decimal("0").isNormal()).toThrow(
+                "Only non-zero numbers can be said to be normal or not"
+            );
         });
         test("simple number with exponent at limit", () => {
             expect(new Decimal("42E-6144").isNormal()).toStrictEqual(true);


### PR DESCRIPTION
The NaN, infinity, and zero cases in `isNormal()` only asserted that a `RangeError` was thrown, not its message. That let several mutants Stryker surfaced survive: emptying any of the three error-message strings, or dropping the NaN guard (which then falls through to the non-finite branch, also a `RangeError`), looked identical under a type-only check. Each case now asserts both the type and the message.