### PR TITLE
Assert error-message text in throw tests

### DIFF
--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -45,6 +45,7 @@ describe("constructor", () => {
         });
         test("empty string not OK", () => {
             expect(() => new Decimal("")).toThrow(SyntaxError);
+            expect(() => new Decimal("")).toThrow("Empty string not permitted");
         });
         test("whitespace plus number not OK", () => {
             expect(() => new Decimal(" 42")).toThrow(SyntaxError);
@@ -93,6 +94,9 @@ describe("constructor", () => {
     describe("exponential string syntax", () => {
         test("nonsense string input", () => {
             expect(() => new Decimal("howdy")).toThrow(SyntaxError);
+            expect(() => new Decimal("howdy")).toThrow(
+                "Invalid decimal string"
+            );
         });
         test("too many significant digits get rounded", () => {
             expect(
@@ -186,18 +190,27 @@ describe("constructor", () => {
             });
             test("period", () => {
                 expect(() => new Decimal(".")).toThrow(SyntaxError);
+                expect(() => new Decimal(".")).toThrow(
+                    "Lone decimal point not permitted"
+                );
             });
             test("plus period", () => {
                 expect(() => new Decimal("+.")).toThrow(SyntaxError);
             });
             test("minus period", () => {
                 expect(() => new Decimal("-.")).toThrow(SyntaxError);
+                expect(() => new Decimal("-.")).toThrow(
+                    "Lone minus sign and period not permitted"
+                );
             });
             test("plus", () => {
                 expect(() => new Decimal("+")).toThrow(SyntaxError);
             });
             test("minus", () => {
                 expect(() => new Decimal("-")).toThrow(SyntaxError);
+                expect(() => new Decimal("-")).toThrow(
+                    "Lone minus sign not permitted"
+                );
             });
         });
     });

--- a/tests/Decimal/exponent.test.js
+++ b/tests/Decimal/exponent.test.js
@@ -4,6 +4,9 @@ describe("exponent", () => {
     describe("NaN", () => {
         test("throws", () => {
             expect(() => new Decimal("NaN").exponent()).toThrow(RangeError);
+            expect(() => new Decimal("NaN").exponent()).toThrow(
+                "Cannot determine exponent for NaN"
+            );
         });
     });
 

--- a/tests/Decimal/issubnormal.test.js
+++ b/tests/Decimal/issubnormal.test.js
@@ -4,6 +4,9 @@ describe("isSubnormal", () => {
     describe("NaN", () => {
         test("throws", () => {
             expect(() => new Decimal("NaN").isSubnormal()).toThrow(RangeError);
+            expect(() => new Decimal("NaN").isSubnormal()).toThrow(
+                "Cannot determine whether NaN is subnormal"
+            );
         });
     });
 

--- a/tests/Decimal/mantissa.test.js
+++ b/tests/Decimal/mantissa.test.js
@@ -3,6 +3,9 @@ import { Decimal } from "../../src/Decimal.mjs";
 describe("mantissa", () => {
     test("0", () => {
         expect(() => new Decimal("0").mantissa()).toThrow(RangeError);
+        expect(() => new Decimal("0").mantissa()).toThrow(
+            "Zero does not have a mantissa"
+        );
     });
     test("0.0", () => {
         expect(() => new Decimal("0.0").mantissa()).toThrow(RangeError);

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -65,9 +65,15 @@ describe("round", () => {
     });
     test("negative number of digits requested is truncation", () => {
         expect(() => new Decimal("1.5").round(-42)).toThrow(RangeError);
+        expect(() => new Decimal("1.5").round(-42)).toThrow(
+            "Invalid number of decimal digits"
+        );
     });
     test("too many digits requested", () => {
         expect(() => new Decimal("1.5").round(2 ** 53)).toThrow(RangeError);
+        expect(() => new Decimal("1.5").round(2 ** 53)).toThrow(
+            "Too many decimal digits requested"
+        );
     });
     test("round to zero", () => {
         expect(new Decimal("0.5").round(0, "trunc").toString()).toStrictEqual(
@@ -84,6 +90,9 @@ describe("round", () => {
         test("throws", () => {
             expect(() => new Decimal("1.5").round(0, "foobar")).toThrow(
                 RangeError
+            );
+            expect(() => new Decimal("1.5").round(0, "foobar")).toThrow(
+                'Invalid rounding mode "foobar"'
             );
         });
     });

--- a/tests/Decimal/scale10.test.js
+++ b/tests/Decimal/scale10.test.js
@@ -4,6 +4,9 @@ describe("scale10", () => {
     describe("NaN", () => {
         test("throws", () => {
             expect(() => new Decimal("NaN").scale10(5)).toThrow(RangeError);
+            expect(() => new Decimal("NaN").scale10(5)).toThrow(
+                "NaN cannot be scaled"
+            );
         });
     });
     describe("simple examples", () => {
@@ -25,12 +28,18 @@ describe("scale10", () => {
         });
         test("non-integer argument", () => {
             expect(() => new Decimal("42").scale10(1.5)).toThrow(TypeError);
+            expect(() => new Decimal("42").scale10(1.5)).toThrow(
+                "Argument must be an integer"
+            );
         });
     });
     describe("infinty", () => {
         test("positive infinity throws", () => {
             expect(() => new Decimal("Infinity").scale10(5)).toThrow(
                 RangeError
+            );
+            expect(() => new Decimal("Infinity").scale10(5)).toThrow(
+                "Infinity cannot be scaled"
             );
         });
         test("negative infinity throws", () => {

--- a/tests/Decimal/significand.test.js
+++ b/tests/Decimal/significand.test.js
@@ -4,12 +4,18 @@ describe("significand", () => {
     describe("NaN", () => {
         test("throws", () => {
             expect(() => new Decimal("NaN").significand()).toThrow(RangeError);
+            expect(() => new Decimal("NaN").significand()).toThrow(
+                "NaN does not have a scaled significand"
+            );
         });
     });
     describe("infinities", () => {
         test("positive throws", () => {
             expect(() => new Decimal("Infinity").significand()).toThrow(
                 RangeError
+            );
+            expect(() => new Decimal("Infinity").significand()).toThrow(
+                "Infinity does not have a scaled significand"
             );
         });
         test("negative throws", () => {

--- a/tests/Decimal/tobigint.test.js
+++ b/tests/Decimal/tobigint.test.js
@@ -4,6 +4,9 @@ describe("toBigInt", () => {
     describe("NaN", () => {
         test("does not work", () => {
             expect(() => new Decimal("NaN").toBigInt()).toThrow(RangeError);
+            expect(() => new Decimal("NaN").toBigInt()).toThrow(
+                "NaN cannot be converted to a BigInt"
+            );
         });
     });
 
@@ -20,6 +23,9 @@ describe("toBigInt", () => {
         test("positive", () => {
             expect(() => new Decimal("Infinity").toBigInt()).toThrow(
                 RangeError
+            );
+            expect(() => new Decimal("Infinity").toBigInt()).toThrow(
+                "Infinity cannot be converted to a BigInt"
             );
         });
         test("negative", () => {

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -34,6 +34,9 @@ describe("toExponential", () => {
     });
     test("wrong argument type", () => {
         expect(() => decimalD.toExponential("foo")).toThrow(TypeError);
+        expect(() => decimalD.toExponential("foo")).toThrow(
+            "Argument must be an object"
+        );
     });
     test("empty options", () => {
         expect(decimalD.toExponential({})).toStrictEqual("1.23456e+2");
@@ -66,6 +69,9 @@ describe("toExponential", () => {
     });
     test("zero decimal places throws", () => {
         expect(() => decimalD.toExponential({ digits: 0 })).toThrow(RangeError);
+        expect(() => decimalD.toExponential({ digits: 0 })).toThrow(
+            "Argument must be positive"
+        );
     });
     test("negative number of decimal places", () => {
         expect(() => decimalD.toExponential({ digits: -1 })).toThrow(
@@ -75,6 +81,9 @@ describe("toExponential", () => {
     test("non-integer number throws", () => {
         expect(() => decimalD.toExponential({ digits: 1.5 })).toThrow(
             RangeError
+        );
+        expect(() => decimalD.toExponential({ digits: 1.5 })).toThrow(
+            "Argument must be an integer"
         );
     });
     describe("negative", () => {

--- a/tests/Decimal/tofixed.test.js
+++ b/tests/Decimal/tofixed.test.js
@@ -75,12 +75,18 @@ describe("toFixed", () => {
         });
         test("negative number of decimal places throws", () => {
             expect(() => decimalD.toFixed({ digits: -1 })).toThrow(RangeError);
+            expect(() => decimalD.toFixed({ digits: -1 })).toThrow(
+                "Argument must be greater than or equal to 0"
+            );
         });
         test("non-integer does not take floor", () => {
             expect(() => decimalD.toFixed({ digits: 1.5 })).toThrow(RangeError);
         });
         test("non-object argument", () => {
             expect(() => decimalD.toFixed("flab")).toThrow(TypeError);
+            expect(() => decimalD.toFixed("flab")).toThrow(
+                "Argument must be an object"
+            );
         });
         test("zeroes get added", () => {
             expect(new Decimal("42").toFixed({ digits: 10 })).toStrictEqual(

--- a/tests/Decimal/toprecision.test.js
+++ b/tests/Decimal/toprecision.test.js
@@ -87,6 +87,9 @@ describe("toPrecision", () => {
         let d = new Decimal("123.456");
         test("non-object argument throws", () => {
             expect(() => d.toPrecision("whatever")).toThrow(TypeError);
+            expect(() => d.toPrecision("whatever")).toThrow(
+                "Argument must be an object"
+            );
         });
         test("object argument given, but has weird property", () => {
             expect(d.toPrecision({ foo: "bar" }).toString()).toStrictEqual(
@@ -97,10 +100,16 @@ describe("toPrecision", () => {
             expect(() => d.toPrecision({ digits: 1.72 }).toString()).toThrow(
                 RangeError
             );
+            expect(() => d.toPrecision({ digits: 1.72 }).toString()).toThrow(
+                "Argument must be an integer"
+            );
         });
         test("negative integer number of digits requested", () => {
             expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
                 RangeError
+            );
+            expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
+                "Argument must be positive"
             );
         });
     });

--- a/tests/Decimal/valueof.test.js
+++ b/tests/Decimal/valueof.test.js
@@ -5,5 +5,8 @@ describe("valueOf", () => {
         expect(() => {
             return 42 - new Decimal("42");
         }).toThrow(TypeError);
+        expect(() => {
+            return 42 - new Decimal("42");
+        }).toThrow("Decimal.prototype.valueOf throws unconditionally");
     });
 });


### PR DESCRIPTION
Assert the message text (not just the error type) in 27 `.toThrow()` sites flagged by mutation testing.