### PR TITLE
Test that roundingMode option actually changes the result

### DIFF
--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -119,6 +119,16 @@ describe("addition", () => {
                     .toString()
             ).toStrictEqual("1.234567890123456789012345678901234e+33");
         });
+        test("rounding mode changes the result (ceil vs default)", () => {
+            const a = new Decimal("1.234567890123456789012345678901234");
+            const b = new Decimal("0.0000000000000000000000000000000005");
+            expect(a.add(b, { roundingMode: "ceil" }).toString()).toStrictEqual(
+                "1.234567890123456789012345678901235"
+            );
+            expect(a.add(b).toString()).toStrictEqual(
+                "1.234567890123456789012345678901234"
+            );
+        });
     });
     describe("examples from the General Decimal Arithmetic specification", () => {
         test("example one", () => {

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -394,6 +394,17 @@ describe("division", () => {
                     val1.divide(val2, { roundingMode: "floor" }).toString()
                 ).toStrictEqual("3.333333333333333333333333333333333e+6143");
             });
+
+            test("rounding mode changes the result (ceil vs default)", () => {
+                const a = new Decimal("1");
+                const b = new Decimal("3");
+                expect(
+                    a.divide(b, { roundingMode: "ceil" }).toString()
+                ).toStrictEqual("0.3333333333333333333333333333333334");
+                expect(a.divide(b).toString()).toStrictEqual(
+                    "0.3333333333333333333333333333333333"
+                );
+            });
         });
     });
 });


### PR DESCRIPTION
The `add`/`divide` rounding-mode tests picked arguments where every mode (including the `halfEven` default) gives the same result, so they didn't actually verify the option is honored. Mutation testing with Stryker flagged the opts-handling mutants as surviving. This adds `ceil`-vs-default cases where the mode genuinely changes the last digit.