### PR TITLE
Fix toPrecision not padding integer results to requested precision

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -620,9 +620,16 @@ class CoefficientExponent {
             const sign = rounded._isNegative ? "-" : "";
 
             if (rounded._exponent >= 0) {
-                // No decimal point needed
+                // Whole number
                 const totalDigits = coeffStr.length + rounded._exponent;
-                return sign + coeffStr + "0".repeat(rounded._exponent);
+                const intStr = coeffStr + "0".repeat(rounded._exponent);
+                if (totalDigits < digits) {
+                    // Pad with trailing zeros to reach the requested precision
+                    return (
+                        sign + intStr + "." + "0".repeat(digits - totalDigits)
+                    );
+                }
+                return sign + intStr;
             } else {
                 // Need decimal point
                 const absExp = -rounded._exponent;
@@ -665,6 +672,12 @@ class CoefficientExponent {
                 // Single digit coefficient
                 const expSign = effectiveExponent >= 0 ? "+" : "";
                 const expStr = "e" + expSign + effectiveExponent;
+                if (digits > 1) {
+                    // Pad with trailing zeros to reach the requested precision
+                    return (
+                        sign + coeffStr + "." + "0".repeat(digits - 1) + expStr
+                    );
+                }
                 return sign + coeffStr + expStr;
             } else {
                 // Multiple digit coefficient

--- a/tests/Decimal/toprecision.test.js
+++ b/tests/Decimal/toprecision.test.js
@@ -187,6 +187,26 @@ describe("toPrecision", () => {
                 }
             );
         });
+        describe("integer result padded to the requested precision", () => {
+            test.each`
+                input    | digits | output
+                ${"5"}   | ${3}   | ${"5.00"}
+                ${"16"}  | ${4}   | ${"16.00"}
+                ${"123"} | ${5}   | ${"123.00"}
+                ${"100"} | ${5}   | ${"100.00"}
+                ${"100"} | ${3}   | ${"100"}
+                ${"9"}   | ${2}   | ${"9.0"}
+                ${"9"}   | ${1}   | ${"9"}
+                ${"100"} | ${2}   | ${"1.0e+2"}
+                ${"-5"}  | ${3}   | ${"-5.00"}
+            `(
+                "$input precision($digits) = $output",
+                ({ input, digits, output }) => {
+                    const s = new Decimal(input).toPrecision({ digits });
+                    expect(s).toStrictEqual(output);
+                }
+            );
+        });
         describe("with decimal output", () => {
             test.each`
                 input      | digits | output


### PR DESCRIPTION
toPrecision padded trailing significant zeros for fractional results (e.g. `1.6` @4 → `"1.600"`) but not when the rounded result was a whole number or a single-digit exponential (`5` with 3 significant digits gave `"5"` instead of `"5.00"`, `100` with 2 significant digits gave `"1e+2"` instead of `"1.0e+2"`); this wires up the missing padding in both branches (using the previously-dead `totalDigits` local), matching `Number.prototype.toPrecision` apart from the proposal's halfEven default, and resolves the integer-result half of #15.