### PR TITLE
Simplify RoundToDecimal128Domain bounds checks

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -16,6 +16,13 @@
 const NORMAL_EXPONENT_MIN = -6143;
 const MAX_SIGNIFICANT_DIGITS = 34;
 
+// The largest adjusted exponent of a finite Decimal128 value (Emax); above it,
+// values round to infinity.
+const ADJUSTED_EXPONENT_MAX = 6144;
+// The adjusted exponent of the smallest subnormal value (Etiny = Emin -
+// (precision - 1)); below it, values round to zero.
+const TINY_EXPONENT_MIN = NORMAL_EXPONENT_MIN - (MAX_SIGNIFICANT_DIGITS - 1);
+
 type NaNValue = "NaN";
 type InfiniteValue = "Infinity" | "-Infinity";
 type FiniteValue = "0" | "-0" | CoefficientExponent;
@@ -739,44 +746,28 @@ function RoundToDecimal128Domain(
         return (d as CoefficientExponent).negate();
     }
 
-    // Get the number of significant digits
+    // Reduce precision to fit the significand if needed. Rounding can only
+    // carry the adjusted exponent upward (e.g. 999 -> 1000), never lower it, so
+    // the bounds checks below are exact on the rounded result.
     const sigDigits = v.coefficient.toString().length;
-    const currentExponent = v.exponent;
-
-    // Calculate the effective exponent (where the decimal point would be after the first digit)
-    const effectiveExponent = currentExponent + sigDigits - 1;
-
-    // Check if we're above the normal range
-    if (effectiveExponent > 6144) {
-        // Check if we can fit in the extreme range
-        if (effectiveExponent > 6111 + 33) {
-            return "Infinity";
-        }
-    }
-
-    // Check if we need to reduce precision to fit
     let result = v;
     if (sigDigits > MAX_SIGNIFICANT_DIGITS) {
-        // Need to round to 34 significant digits
         result = v.roundToSignificantDigits(MAX_SIGNIFICANT_DIGITS, mode);
     }
 
-    // Check final exponent bounds
-    const finalExp = result.exponent + result.coefficient.toString().length - 1;
-    if (finalExp > 6144) {
-        // We're in the extreme range, check if we exceed it
-        const digitsAvailable = Math.max(1, 34 - (finalExp - 6144));
-        if (digitsAvailable < 1 || finalExp > 6111 + 33) {
-            return "Infinity";
-        }
+    // The adjusted exponent is the power of ten of the leading significant
+    // digit.
+    const adjustedExponent =
+        result.exponent + result.coefficient.toString().length - 1;
+
+    // Above the largest finite value, round to infinity.
+    if (adjustedExponent > ADJUSTED_EXPONENT_MAX) {
+        return "Infinity";
     }
 
-    // Check for subnormal (very small) values
-    if (finalExp < -6143) {
-        const digitsAvailable = Math.max(0, 34 + (finalExp + 6143));
-        if (digitsAvailable <= 0) {
-            return "0";
-        }
+    // Below the smallest subnormal value, round to zero.
+    if (adjustedExponent < TINY_EXPONENT_MIN) {
+        return "0";
     }
 
     if (result.isZero()) {

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -132,6 +132,53 @@ describe("constructor", () => {
         });
     });
 
+    describe("Decimal128 domain boundaries", () => {
+        // The largest finite value has adjusted exponent 6144; one step past
+        // it overflows to Infinity.
+        describe("overflow at adjusted exponent 6144", () => {
+            test("adjusted exponent 6144 is finite", () => {
+                expect(new Decimal("1E+6144").toString()).toStrictEqual(
+                    "1e+6144"
+                );
+            });
+            test("adjusted exponent 6145 overflows to Infinity", () => {
+                expect(new Decimal("1E+6145").toString()).toStrictEqual(
+                    "Infinity"
+                );
+            });
+        });
+
+        // Rounding to 34 significant digits can carry, pushing the adjusted
+        // exponent from 6144 up to 6145 and overflowing.
+        describe("overflow when rounding carries past 6144", () => {
+            const thirtyFiveNines = "9".repeat(35);
+            test("carry that stays at 6144 is finite", () => {
+                // 35 nines at adjusted exponent 6143 round up to 1e+6144.
+                expect(
+                    new Decimal(thirtyFiveNines + "E6109").toString()
+                ).toStrictEqual("1e+6144");
+            });
+            test("carry from 6144 to 6145 overflows to Infinity", () => {
+                // 35 nines at adjusted exponent 6144 round up to 1e+6145.
+                expect(
+                    new Decimal(thirtyFiveNines + "E6110").toString()
+                ).toStrictEqual("Infinity");
+            });
+        });
+
+        // Values with adjusted exponent at or below -6177 underflow to zero.
+        describe("underflow to zero at adjusted exponent -6177", () => {
+            test("adjusted exponent -6176 is finite", () => {
+                expect(new Decimal("1E-6176").toString()).toStrictEqual(
+                    "1e-6143"
+                );
+            });
+            test("adjusted exponent -6177 underflows to zero", () => {
+                expect(new Decimal("1E-6177").toString()).toStrictEqual("0");
+            });
+        });
+    });
+
     describe("NaN", () => {
         test("invalid NaN variations throw", () => {
             expect(() => new Decimal("-NaN")).toThrow(SyntaxError);


### PR DESCRIPTION
Refactors the three exponent-bound checks in `RoundToDecimal128Domain` to kill surviving mutants flagged by Stryker. They were redundant or dead code (a fully-redundant pre-rounding overflow guard, plus two checks with always-true/always-false sub-conditions), so they couldn't be killed without rewriting; collapsing them to single comparisons against named, spec-derived constants removes the dead code and makes the boundaries testable.

Behavior is unchanged — all 919 tests pass, including the dectest conformance suite. New boundary tests cover overflow at 6144/6145 (incl. the rounding-carry case) and underflow at -6176/-6177. Full-file mutation score 85.10% -> 87.14%.

Refs #77.