### PR TITLE
Report true subnormal exponents instead of clamping to Emin (#82)

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -1989,7 +1989,7 @@ export class Decimal {
         }
 
         if (this.isNegative()) {
-            return this.negate().exponent();
+            return this.negate().unrestrictedExponent();
         }
 
         let v = this.d as CoefficientExponent;
@@ -2000,9 +2000,10 @@ export class Decimal {
     }
 
     /**
-     * Returns the exponent of this Decimal128 value.
-     * For normal numbers, this is the actual exponent.
-     * For subnormal numbers, this returns the minimum normal exponent.
+     * Returns the adjusted exponent of this Decimal128 value: the exponent
+     * of the most significant digit when written in scientific notation.
+     * For subnormal values this ranges down to Etiny (Emin - (precision - 1)
+     * = -6176); it is reported truthfully rather than clamped to Emin.
      *
      * @returns {number} The exponent value
      * @throws {RangeError} If this value is NaN or infinite
@@ -2018,8 +2019,13 @@ export class Decimal {
             );
         }
 
-        let te = this.unrestrictedExponent();
-        return Math.max(te, NORMAL_EXPONENT_MIN);
+        // Zero has no significant digits and so no meaningful adjusted
+        // exponent; report Emin by convention.
+        if (this.isZero()) {
+            return NORMAL_EXPONENT_MIN;
+        }
+
+        return this.unrestrictedExponent();
     }
 
     /**

--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -205,17 +205,15 @@ describe("addition", () => {
             });
 
             test("add two subnormal values", () => {
-                // Currently, very small values are normalized to E-6143
                 const sub1 = new Decimal("5E-6150");
                 const sub2 = new Decimal("3E-6150");
-                expect(sub1.add(sub2).toString()).toStrictEqual("8e-6143");
+                expect(sub1.add(sub2).toString()).toStrictEqual("8e-6150");
             });
 
             test("add values in deep subnormal range", () => {
-                // Currently, very small values are normalized to E-6143
                 const sub1 = new Decimal("1E-6170");
                 const sub2 = new Decimal("1E-6170");
-                expect(sub1.add(sub2).toString()).toStrictEqual("2e-6143");
+                expect(sub1.add(sub2).toString()).toStrictEqual("2e-6170");
             });
 
             test("add values that are too small (below subnormal)", () => {

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -119,8 +119,10 @@ describe("constructor", () => {
             );
         });
         test("min exponent", () => {
+            // 123E-6177 = 1.23E-6175, a subnormal whose adjusted exponent
+            // (-6175) is reported truthfully rather than clamped to Emin.
             expect(new Decimal("123E-6177").toString()).toStrictEqual(
-                "1.23e-6143"
+                "1.23e-6175"
             );
         });
         test("integer too big", () => {
@@ -170,7 +172,7 @@ describe("constructor", () => {
         describe("underflow to zero at adjusted exponent -6177", () => {
             test("adjusted exponent -6176 is finite", () => {
                 expect(new Decimal("1E-6176").toString()).toStrictEqual(
-                    "1e-6143"
+                    "1e-6176"
                 );
             });
             test("adjusted exponent -6177 underflows to zero", () => {

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -250,9 +250,9 @@ describe("division", () => {
             test("divide subnormal by normal", () => {
                 const subnormal = new Decimal("1E-6150");
                 const normal = new Decimal("10");
-                // Result normalizes to E-6143
+                // 1E-6150 / 10 = 1E-6151, still in the subnormal range
                 expect(subnormal.divide(normal).toString()).toStrictEqual(
-                    "1e-6143"
+                    "1e-6151"
                 );
             });
 
@@ -346,8 +346,8 @@ describe("division", () => {
                     "9.999999999999999999999999999999999E+6144"
                 );
                 const one = new Decimal("1");
-                // 1 / max normalizes to 1E-6143
-                expect(one.divide(max).toString()).toStrictEqual("1e-6143");
+                // 1 / 9.99...9E+6144 rounds to 1E-6145, a subnormal value
+                expect(one.divide(max).toString()).toStrictEqual("1e-6145");
             });
 
             test("reciprocal of minimum normal", () => {

--- a/tests/Decimal/exponent.test.js
+++ b/tests/Decimal/exponent.test.js
@@ -46,8 +46,8 @@ describe("exponent", () => {
 
     // Subnormal values have adjusted exponents below Emin (-6143), down to
     // Etiny = Emin - (precision - 1) = -6176. The exponent must be reported
-    // truthfully rather than clamped up to Emin. See issue #82.
-    describe("subnormal range (issue #82)", () => {
+    // truthfully rather than clamped up to Emin.
+    describe("subnormal range", () => {
         test("just below the normal boundary", () => {
             expect(new Decimal("1E-6144").exponent()).toStrictEqual(-6144);
         });

--- a/tests/Decimal/exponent.test.js
+++ b/tests/Decimal/exponent.test.js
@@ -39,8 +39,30 @@ describe("exponent", () => {
         test("simple number between 1 and 10 with exponent apparently at limit", () => {
             expect(new Decimal("4.22E-6143").exponent()).toStrictEqual(-6143);
         });
-        test("simple number with exponent beyond limit", () => {
-            expect(new Decimal("4.22E-6144").exponent()).toStrictEqual(-6143);
+        test("subnormal number reports its true (sub-Emin) exponent", () => {
+            expect(new Decimal("4.22E-6144").exponent()).toStrictEqual(-6144);
+        });
+    });
+
+    // Subnormal values have adjusted exponents below Emin (-6143), down to
+    // Etiny = Emin - (precision - 1) = -6176. The exponent must be reported
+    // truthfully rather than clamped up to Emin. See issue #82.
+    describe("subnormal range (issue #82)", () => {
+        test("just below the normal boundary", () => {
+            expect(new Decimal("1E-6144").exponent()).toStrictEqual(-6144);
+        });
+        test("middle of the subnormal range", () => {
+            expect(new Decimal("1.5E-6160").exponent()).toStrictEqual(-6160);
+        });
+        test("smallest subnormal (Etiny)", () => {
+            expect(new Decimal("1E-6176").exponent()).toStrictEqual(-6176);
+        });
+        test("coefficient with several digits", () => {
+            // 123E-6177 = 1.23E-6175, adjusted exponent -6175
+            expect(new Decimal("123E-6177").exponent()).toStrictEqual(-6175);
+        });
+        test("negative subnormal reports the true exponent", () => {
+            expect(new Decimal("-1E-6144").exponent()).toStrictEqual(-6144);
         });
     });
 });

--- a/tests/Decimal/isnormal.test.js
+++ b/tests/Decimal/isnormal.test.js
@@ -46,5 +46,13 @@ describe("isNormal", () => {
         test("number with exponent at upper limit is normal", () => {
             expect(new Decimal("1E+6144").isNormal()).toStrictEqual(true);
         });
+        // Classification must not depend on sign: a negative subnormal is not
+        // normal, just like its positive counterpart. See issue #82.
+        test("negative subnormal is not normal", () => {
+            expect(new Decimal("-1E-6144").isNormal()).toStrictEqual(false);
+        });
+        test("negative normal is normal", () => {
+            expect(new Decimal("-42").isNormal()).toStrictEqual(true);
+        });
     });
 });

--- a/tests/Decimal/isnormal.test.js
+++ b/tests/Decimal/isnormal.test.js
@@ -47,7 +47,7 @@ describe("isNormal", () => {
             expect(new Decimal("1E+6144").isNormal()).toStrictEqual(true);
         });
         // Classification must not depend on sign: a negative subnormal is not
-        // normal, just like its positive counterpart. See issue #82.
+        // normal, just like its positive counterpart.
         test("negative subnormal is not normal", () => {
             expect(new Decimal("-1E-6144").isNormal()).toStrictEqual(false);
         });

--- a/tests/Decimal/issubnormal.test.js
+++ b/tests/Decimal/issubnormal.test.js
@@ -37,7 +37,7 @@ describe("isSubnormal", () => {
             expect(new Decimal("42E-6145").isSubnormal()).toStrictEqual(true);
         });
         // Classification must not depend on sign: a negative value is
-        // subnormal exactly when its magnitude is. See issue #82.
+        // subnormal exactly when its magnitude is.
         test("negative subnormal is subnormal", () => {
             expect(new Decimal("-1E-6144").isSubnormal()).toStrictEqual(true);
         });

--- a/tests/Decimal/issubnormal.test.js
+++ b/tests/Decimal/issubnormal.test.js
@@ -36,5 +36,16 @@ describe("isSubnormal", () => {
         test("simple number with exponent beyond limit", () => {
             expect(new Decimal("42E-6145").isSubnormal()).toStrictEqual(true);
         });
+        // Classification must not depend on sign: a negative value is
+        // subnormal exactly when its magnitude is. See issue #82.
+        test("negative subnormal is subnormal", () => {
+            expect(new Decimal("-1E-6144").isSubnormal()).toStrictEqual(true);
+        });
+        test("negative deep subnormal is subnormal", () => {
+            expect(new Decimal("-1E-6176").isSubnormal()).toStrictEqual(true);
+        });
+        test("negative normal is not subnormal", () => {
+            expect(new Decimal("-42").isSubnormal()).toStrictEqual(false);
+        });
     });
 });

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -284,9 +284,9 @@ describe("multiply", () => {
                 // sqrt(min subnormal) ≈ 1E-3088
                 const small1 = new Decimal("1E-3088");
                 const small2 = new Decimal("1E-3088");
-                // Should produce 1E-6176
+                // 1E-3088 * 1E-3088 = 1E-6176, the smallest subnormal
                 expect(small1.multiply(small2).toString()).toStrictEqual(
-                    "1e-6143"
+                    "1e-6176"
                 );
             });
 
@@ -379,8 +379,8 @@ describe("multiply", () => {
                 // This tests the boundary of subnormal arithmetic
                 const val = new Decimal("1E-3088");
                 const squared = val.multiply(val);
-                // Should normalize to E-6143
-                expect(squared.toString()).toStrictEqual("1e-6143");
+                // (1E-3088)^2 = 1E-6176, the smallest subnormal
+                expect(squared.toString()).toStrictEqual("1e-6176");
             });
 
             test("multiplication chain near limits", () => {

--- a/tests/Decimal/remainder.test.js
+++ b/tests/Decimal/remainder.test.js
@@ -162,7 +162,7 @@ describe("remainder", () => {
                 const normal = new Decimal("1");
                 // tiny % 1 = tiny (since tiny < 1)
                 expect(tiny.remainder(normal).toString()).toStrictEqual(
-                    "1e-6143"
+                    "1e-6150"
                 );
             });
 
@@ -212,9 +212,9 @@ describe("remainder", () => {
             test("remainder with subnormal values", () => {
                 const sub1 = new Decimal("5E-6150");
                 const sub2 = new Decimal("2E-6150");
-                // Both normalize to E-6143
+                // 5E-6150 % 2E-6150 = 1E-6150, still subnormal
                 const result = sub1.remainder(sub2);
-                expect(result.toString()).toStrictEqual("1e-6143");
+                expect(result.toString()).toStrictEqual("1e-6150");
             });
 
             test("remainder producing zero at extreme", () => {

--- a/tests/Decimal/subtract.test.js
+++ b/tests/Decimal/subtract.test.js
@@ -234,15 +234,15 @@ describe("subtract", () => {
                     "1.000000000000000000000000000000001E-6143"
                 );
                 const val2 = new Decimal("1E-6143");
-                // Result is 1E-6176, which normalizes to E-6143
-                expect(val1.subtract(val2).toString()).toStrictEqual("1e-6143");
+                // Result is 1E-6176, the smallest subnormal
+                expect(val1.subtract(val2).toString()).toStrictEqual("1e-6176");
             });
 
             test("subtract subnormal values", () => {
                 const sub1 = new Decimal("8E-6150");
                 const sub2 = new Decimal("3E-6150");
-                // Currently normalized to E-6143
-                expect(sub1.subtract(sub2).toString()).toStrictEqual("5e-6143");
+                // 8E-6150 - 3E-6150 = 5E-6150, still subnormal
+                expect(sub1.subtract(sub2).toString()).toStrictEqual("5e-6150");
             });
 
             test("subtraction resulting in underflow", () => {

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -143,8 +143,8 @@ describe("toExponential", () => {
     });
 
     // Subnormal values must expose their true exponent down to Etiny
-    // (-6176) rather than being clamped to Emin (-6143). See issue #82.
-    describe("subnormal range (issue #82)", () => {
+    // (-6176) rather than being clamped to Emin (-6143).
+    describe("subnormal range", () => {
         test("just below the normal boundary", () => {
             expect(new Decimal("1E-6144").toExponential()).toStrictEqual(
                 "1e-6144"

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -141,4 +141,24 @@ describe("toExponential", () => {
             expect(new Decimal("0E+2").toExponential()).toStrictEqual("0e+0");
         });
     });
+
+    // Subnormal values must expose their true exponent down to Etiny
+    // (-6176) rather than being clamped to Emin (-6143). See issue #82.
+    describe("subnormal range (issue #82)", () => {
+        test("just below the normal boundary", () => {
+            expect(new Decimal("1E-6144").toExponential()).toStrictEqual(
+                "1e-6144"
+            );
+        });
+        test("smallest subnormal (Etiny)", () => {
+            expect(new Decimal("1E-6176").toExponential()).toStrictEqual(
+                "1e-6176"
+            );
+        });
+        test("negative subnormal keeps its sign and exponent", () => {
+            expect(new Decimal("-1.5E-6160").toExponential()).toStrictEqual(
+                "-1.5e-6160"
+            );
+        });
+    });
 });

--- a/tests/Decimal/tostring.test.js
+++ b/tests/Decimal/tostring.test.js
@@ -96,5 +96,30 @@ describe("toString", () => {
                 );
             });
         });
+
+        // Subnormal values (adjusted exponent in [-6176, -6144]) must render
+        // with their true exponent, not clamped up to Emin (-6143). See #82.
+        describe("subnormal range (issue #82)", () => {
+            test("just below the normal boundary", () => {
+                expect(new Decimal("1E-6144").toString()).toStrictEqual(
+                    "1e-6144"
+                );
+            });
+            test("middle of the subnormal range", () => {
+                expect(new Decimal("1.5E-6160").toString()).toStrictEqual(
+                    "1.5e-6160"
+                );
+            });
+            test("smallest subnormal (Etiny)", () => {
+                expect(new Decimal("1E-6176").toString()).toStrictEqual(
+                    "1e-6176"
+                );
+            });
+            test("negative subnormal keeps its sign and exponent", () => {
+                expect(new Decimal("-1.5E-6160").toString()).toStrictEqual(
+                    "-1.5e-6160"
+                );
+            });
+        });
     });
 });

--- a/tests/Decimal/tostring.test.js
+++ b/tests/Decimal/tostring.test.js
@@ -98,8 +98,8 @@ describe("toString", () => {
         });
 
         // Subnormal values (adjusted exponent in [-6176, -6144]) must render
-        // with their true exponent, not clamped up to Emin (-6143). See #82.
-        describe("subnormal range (issue #82)", () => {
+        // with their true exponent, not clamped up to Emin (-6143).
+        describe("subnormal range", () => {
             test("just below the normal boundary", () => {
                 expect(new Decimal("1E-6144").toString()).toStrictEqual(
                     "1e-6144"


### PR DESCRIPTION
Fixes #82: `toString()`, `toExponential()`, and `exponent()` now report a subnormal value's true adjusted exponent (down to Etiny = -6176) instead of clamping it up to Emin (-6143), and `unrestrictedExponent()` recurses correctly for negatives so negative subnormals are no longer misclassified by `isNormal()`/`isSubnormal()`.