### PR TITLE
Implement multiply/divide/remainder without sign-based recursion

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -1626,24 +1626,18 @@ export class Decimal {
             return new Decimal(NEGATIVE_INFINITY);
         }
 
-        if (this.isNegative()) {
-            return this.negate().multiply(x, opts).negate();
-        }
-
-        if (x.isNegative()) {
-            return this.multiply(x.negate(), opts).negate();
+        // The product's sign is the exclusive-or of the operand signs, which
+        // CoefficientExponent.multiply already applies to non-zero results. A
+        // zero operand still carries that sign, so compute it here directly
+        // rather than deferring to a sign-negating recursive call.
+        if (this.isZero() || x.isZero()) {
+            return new Decimal(
+                this.isNegative() !== x.isNegative() ? "-0" : "0"
+            );
         }
 
         let ourCohort = this.d as CoefficientExponent;
         let theirCohort = x.d as CoefficientExponent;
-
-        if (this.isZero()) {
-            return this.clone();
-        }
-
-        if (x.isZero()) {
-            return x.clone();
-        }
 
         let product = ourCohort.multiply(theirCohort);
         let rounded = RoundToDecimal128Domain(
@@ -1699,8 +1693,13 @@ export class Decimal {
             return new Decimal(NAN);
         }
 
+        // The quotient's sign is the exclusive-or of the operand signs, even
+        // when the dividend is zero (e.g. 0 / -1 is -0, -0 / -1 is +0). This
+        // also covers a zero dividend with an infinite divisor below.
         if (this.isZero()) {
-            return this.clone();
+            return new Decimal(
+                this.isNegative() !== x.isNegative() ? "-0" : "0"
+            );
         }
 
         if (!this.isFinite()) {
@@ -1727,14 +1726,8 @@ export class Decimal {
             return new Decimal("-0");
         }
 
-        if (this.isNegative()) {
-            return this.negate().divide(x, opts).negate();
-        }
-
-        if (x.isNegative()) {
-            return this.divide(x.negate(), opts).negate();
-        }
-
+        // CoefficientExponent.divide applies the exclusive-or of the operand
+        // signs to its result, so no sign-based recursion is needed here.
         let ourV = this.d as CoefficientExponent;
         let theirV = x.d as CoefficientExponent;
         let quotient = ourV.divide(theirV);
@@ -1833,14 +1826,6 @@ export class Decimal {
             return new Decimal(NAN);
         }
 
-        if (this.isNegative()) {
-            return this.negate().remainder(d).negate();
-        }
-
-        if (d.isNegative()) {
-            return this.remainder(d.negate());
-        }
-
         if (!this.isFinite()) {
             return new Decimal(NAN);
         }
@@ -1853,12 +1838,28 @@ export class Decimal {
             return new Decimal(NAN);
         }
 
-        if (this.compare(d) === -1) {
+        // When |this| < |d| the truncated quotient is zero, so the remainder is
+        // the dividend itself (keeping its sign). Comparing magnitudes lets this
+        // shortcut work for every sign combination without recursing through
+        // negate(). Otherwise, this - d * trunc(this / d) is sign-correct on its
+        // own: signed division, multiplication, and subtraction give the
+        // remainder the dividend's sign for all sign combinations.
+        if (this.abs().compare(d.abs()) === -1) {
             return this.clone();
         }
 
         let q = this.divide(d).round(0, ROUNDING_MODE_TRUNCATE);
-        return this.subtract(d.multiply(q));
+        let r = this.subtract(d.multiply(q));
+
+        // A non-zero remainder already carries the dividend's sign (an identity
+        // of truncated division), but an exact-zero remainder comes back as +0
+        // from subtract(). The remainder keeps the dividend's sign even then
+        // (e.g. -1 % 1 is -0), so restore it explicitly.
+        if (r.isZero()) {
+            return new Decimal(this.isNegative() ? "-0" : "0");
+        }
+
+        return r;
     }
 
     /**

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -120,12 +120,7 @@ describe("division", () => {
             );
         });
     });
-    test("negative zero", () => {
-        expect(
-            new Decimal("-0").divide(new Decimal("1")).toString()
-        ).toStrictEqual("-0");
-    });
-    describe("zero dividend takes the sign of the quotient (dqdiv741-744)", () => {
+    describe("zero dividend takes the sign of the quotient", () => {
         test("positive zero by negative is negative zero", () => {
             expect(
                 new Decimal("0").divide(new Decimal("-1")).toString()

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -125,6 +125,38 @@ describe("division", () => {
             new Decimal("-0").divide(new Decimal("1")).toString()
         ).toStrictEqual("-0");
     });
+    describe("zero dividend takes the sign of the quotient (dqdiv741-744)", () => {
+        test("positive zero by negative is negative zero", () => {
+            expect(
+                new Decimal("0").divide(new Decimal("-1")).toString()
+            ).toStrictEqual("-0");
+        });
+        test("negative zero by negative is positive zero", () => {
+            expect(
+                new Decimal("-0").divide(new Decimal("-1")).toString()
+            ).toStrictEqual("0");
+        });
+        test("negative zero by positive is negative zero", () => {
+            expect(
+                new Decimal("-0").divide(new Decimal("1")).toString()
+            ).toStrictEqual("-0");
+        });
+        test("positive zero by positive is positive zero", () => {
+            expect(
+                new Decimal("0").divide(new Decimal("1")).toString()
+            ).toStrictEqual("0");
+        });
+        test("positive zero by negative infinity is negative zero", () => {
+            expect(
+                new Decimal("0").divide(new Decimal("-Infinity")).toString()
+            ).toStrictEqual("-0");
+        });
+        test("negative zero by negative infinity is positive zero", () => {
+            expect(
+                new Decimal("-0").divide(new Decimal("-Infinity")).toString()
+            ).toStrictEqual("0");
+        });
+    });
     test("negative argument", () => {
         expect(
             new Decimal("42.6").divide(new Decimal("-2.0")).toString()

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -90,6 +90,17 @@ describe("multiply", () => {
                 new Decimal("-0.0").multiply(posZero).toString()
             ).toStrictEqual("-0");
         });
+        test("negative zero times negative zero is positive zero", () => {
+            expect(negZero.multiply(negZero).toString()).toStrictEqual("0");
+        });
+        test("positive zero times negative zero is negative zero", () => {
+            expect(posZero.multiply(negZero).toString()).toStrictEqual("-0");
+        });
+        test("negative number times positive zero is negative zero", () => {
+            expect(
+                new Decimal("-3").multiply(posZero).toString()
+            ).toStrictEqual("-0");
+        });
     });
     describe("NaN", () => {
         test("NaN times NaN is NaN", () => {

--- a/tests/Decimal/remainder.test.js
+++ b/tests/Decimal/remainder.test.js
@@ -39,7 +39,12 @@ describe("remainder", () => {
             new Decimal("10").remainder(new Decimal("5")).toString()
         ).toStrictEqual("0");
     });
-    describe("an exact-zero remainder keeps the dividend's sign (dqrem651-657)", () => {
+    test("negative zero dividend keeps its sign", () => {
+        expect(
+            new Decimal("-0").remainder(new Decimal("1")).toString()
+        ).toStrictEqual("-0");
+    });
+    describe("an exact-zero remainder keeps the dividend's sign", () => {
         test("negative dividend cleanly divided is negative zero", () => {
             expect(
                 new Decimal("-1").remainder(new Decimal("1")).toString()
@@ -48,16 +53,6 @@ describe("remainder", () => {
         test("negative dividend, negative divisor, clean is negative zero", () => {
             expect(
                 new Decimal("-1").remainder(new Decimal("-1")).toString()
-            ).toStrictEqual("-0");
-        });
-        test("positive dividend cleanly divided is positive zero", () => {
-            expect(
-                new Decimal("1").remainder(new Decimal("1")).toString()
-            ).toStrictEqual("0");
-        });
-        test("negative zero dividend is negative zero", () => {
-            expect(
-                new Decimal("-0").remainder(new Decimal("1")).toString()
             ).toStrictEqual("-0");
         });
     });

--- a/tests/Decimal/remainder.test.js
+++ b/tests/Decimal/remainder.test.js
@@ -39,6 +39,28 @@ describe("remainder", () => {
             new Decimal("10").remainder(new Decimal("5")).toString()
         ).toStrictEqual("0");
     });
+    describe("an exact-zero remainder keeps the dividend's sign (dqrem651-657)", () => {
+        test("negative dividend cleanly divided is negative zero", () => {
+            expect(
+                new Decimal("-1").remainder(new Decimal("1")).toString()
+            ).toStrictEqual("-0");
+        });
+        test("negative dividend, negative divisor, clean is negative zero", () => {
+            expect(
+                new Decimal("-1").remainder(new Decimal("-1")).toString()
+            ).toStrictEqual("-0");
+        });
+        test("positive dividend cleanly divided is positive zero", () => {
+            expect(
+                new Decimal("1").remainder(new Decimal("1")).toString()
+            ).toStrictEqual("0");
+        });
+        test("negative zero dividend is negative zero", () => {
+            expect(
+                new Decimal("-0").remainder(new Decimal("1")).toString()
+            ).toStrictEqual("-0");
+        });
+    });
     describe("NaN", () => {
         test("NaN remainder NaN is NaN", () => {
             expect(


### PR DESCRIPTION
Refactor multiply, divide, and remainder to drop the negate()-wrapped recursive sign handling, mirroring #89; the underlying signed arithmetic already carries the sign. Also fixes a latent signed-zero bug in divide, where a zero dividend ignored the divisor's sign (0 / -1 now gives -0).