### PR TITLE
Require Node <=24 for development and raise coverage gate to 100%

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,6 +28,6 @@ jobs:
             - name: generate coverage
               run: npm run coverage
             - name: check coverage
-              run: npx c8 check-coverage --lines 99 --functions 99 --branches 99 --statements 99
+              run: npx c8 check-coverage --lines 100 --functions 100 --branches 100 --statements 100
             - name: examples do not crash
               run: for f in examples/*.ts; do node "$f" || (echo "'$f' crashed"; exit 1); done

--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
         "url": "https://github.com/jessealama/proposal-decimal-polyfill.git"
     },
     "type": "module",
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": "^24",
+            "onFail": "error"
+        }
+    },
     "keywords": [
         "decimal",
         "number",


### PR DESCRIPTION
Declares a `devEngines` runtime version of `^24` (matching the Node version pinned in `.nvmrc`) with `onFail: error`, so any npm operation in this repo on a different Node — including the Node 26 default that prevents c8 from starting — fails fast with `EBADDEVENGINES` instead of a cryptic yargs stack trace. `devEngines` applies only to development of this package and is never surfaced to consumers, who can keep using the polyfill on any Node. Also raises the four CI coverage thresholds from 99% to 100%, since the suite already covers everything.