### PR TITLE
Share special-value constants across the test suite

### DIFF
--- a/tests/Decimal/abs.test.js
+++ b/tests/Decimal/abs.test.js
@@ -1,24 +1,26 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
 
 describe("abs", () => {
     test("minus zero", () => {
-        expect(new Decimal("-0").abs().toString()).toStrictEqual("0");
+        expect(NEGATIVE_ZERO.abs().toString()).toStrictEqual("0");
     });
     test("NaN", () => {
-        expect(new Decimal("NaN").abs().toString()).toStrictEqual("NaN");
+        expect(NAN.abs().toString()).toStrictEqual("NaN");
     });
     test("-Infinity", () => {
-        expect(new Decimal("-Infinity").abs().toString()).toStrictEqual(
-            "Infinity"
-        );
+        expect(NEGATIVE_INFINITY.abs().toString()).toStrictEqual("Infinity");
     });
     test("Infinity", () => {
-        expect(new Decimal("Infinity").abs().toString()).toStrictEqual(
-            "Infinity"
-        );
+        expect(POSITIVE_INFINITY.abs().toString()).toStrictEqual("Infinity");
     });
     test("limit of digits", () => {
         expect(new Decimal("-" + bigDigits).abs().toString()).toStrictEqual(

--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -1,10 +1,17 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
 
-const zero = new Decimal("0");
-const minusZero = new Decimal("-0");
+const zero = POSITIVE_ZERO;
+const minusZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 const minusOne = new Decimal("-1");
 const two = new Decimal("2");
@@ -64,24 +71,18 @@ describe("addition", () => {
     });
     describe("NaN", () => {
         test("NaN plus NaN is NaN", () => {
-            expect(
-                new Decimal("NaN").add(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.add(NAN).toString()).toStrictEqual("NaN");
         });
         test("NaN plus number", () => {
-            expect(
-                new Decimal("NaN").add(new Decimal("1")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.add(new Decimal("1")).toString()).toStrictEqual("NaN");
         });
         test("number plus NaN", () => {
-            expect(
-                new Decimal("1").add(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(new Decimal("1").add(NAN).toString()).toStrictEqual("NaN");
         });
     });
     describe("infinity", () => {
-        let posInf = new Decimal("Infinity");
-        let negInf = new Decimal("-Infinity");
+        let posInf = POSITIVE_INFINITY;
+        let negInf = NEGATIVE_INFINITY;
         test("positive infinity plus number", () => {
             expect(posInf.add(one).toString()).toStrictEqual("Infinity");
         });

--- a/tests/Decimal/compare.test.js
+++ b/tests/Decimal/compare.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("compare", () => {
@@ -106,8 +113,8 @@ describe("many digits", () => {
         });
     });
     describe("infinity", () => {
-        let posInf = new Decimal("Infinity");
-        let negInf = new Decimal("-Infinity");
+        let posInf = POSITIVE_INFINITY;
+        let negInf = NEGATIVE_INFINITY;
         test("positive infinity vs number", () => {
             expect(posInf.compare(one)).toStrictEqual(1);
         });

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -1,4 +1,11 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 describe("division", () => {
     test("simple example", () => {
@@ -38,35 +45,33 @@ describe("division", () => {
         ).toStrictEqual("0.1");
     });
     test("zero divided by zero", () => {
-        expect(
-            new Decimal("0").divide(new Decimal("0")).toString()
-        ).toStrictEqual("NaN");
+        expect(POSITIVE_ZERO.divide(POSITIVE_ZERO).toString()).toStrictEqual(
+            "NaN"
+        );
     });
     describe("NaN", () => {
         test("NaN divided by NaN is NaN", () => {
-            expect(
-                new Decimal("NaN").divide(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.divide(NAN).toString()).toStrictEqual("NaN");
         });
         test("NaN divided by number is NaN", () => {
-            expect(
-                new Decimal("NaN").divide(new Decimal("1")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.divide(new Decimal("1")).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("number divided by NaN is NaN", () => {
-            expect(
-                new Decimal("1").divide(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(new Decimal("1").divide(NAN).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("divide by zero is NaN", () => {
             expect(
-                new Decimal("42").divide(new Decimal("0")).toString()
+                new Decimal("42").divide(POSITIVE_ZERO).toString()
             ).toStrictEqual("NaN");
         });
     });
     describe("infinity", () => {
-        let posInf = new Decimal("Infinity");
-        let negInf = new Decimal("-Infinity");
+        let posInf = POSITIVE_INFINITY;
+        let negInf = NEGATIVE_INFINITY;
         test("infinity divided by infinity is NaN", () => {
             expect(posInf.divide(posInf).toString()).toStrictEqual("NaN");
         });
@@ -123,32 +128,32 @@ describe("division", () => {
     describe("zero dividend takes the sign of the quotient", () => {
         test("positive zero by negative is negative zero", () => {
             expect(
-                new Decimal("0").divide(new Decimal("-1")).toString()
+                POSITIVE_ZERO.divide(new Decimal("-1")).toString()
             ).toStrictEqual("-0");
         });
         test("negative zero by negative is positive zero", () => {
             expect(
-                new Decimal("-0").divide(new Decimal("-1")).toString()
+                NEGATIVE_ZERO.divide(new Decimal("-1")).toString()
             ).toStrictEqual("0");
         });
         test("negative zero by positive is negative zero", () => {
             expect(
-                new Decimal("-0").divide(new Decimal("1")).toString()
+                NEGATIVE_ZERO.divide(new Decimal("1")).toString()
             ).toStrictEqual("-0");
         });
         test("positive zero by positive is positive zero", () => {
             expect(
-                new Decimal("0").divide(new Decimal("1")).toString()
+                POSITIVE_ZERO.divide(new Decimal("1")).toString()
             ).toStrictEqual("0");
         });
         test("positive zero by negative infinity is negative zero", () => {
             expect(
-                new Decimal("0").divide(new Decimal("-Infinity")).toString()
+                POSITIVE_ZERO.divide(NEGATIVE_INFINITY).toString()
             ).toStrictEqual("-0");
         });
         test("negative zero by negative infinity is positive zero", () => {
             expect(
-                new Decimal("-0").divide(new Decimal("-Infinity")).toString()
+                NEGATIVE_ZERO.divide(NEGATIVE_INFINITY).toString()
             ).toStrictEqual("0");
         });
     });

--- a/tests/Decimal/equals.test.js
+++ b/tests/Decimal/equals.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("equals", () => {
@@ -60,14 +67,10 @@ describe("equals", () => {
                 expect(nan.equals(one)).toStrictEqual(false);
             });
             test("NaN equals positive infinity is false", () => {
-                expect(nan.equals(new Decimal("Infinity"))).toStrictEqual(
-                    false
-                );
+                expect(nan.equals(POSITIVE_INFINITY)).toStrictEqual(false);
             });
             test("positive infinity equals NaN is false", () => {
-                expect(new Decimal("Infinity").equals(nan)).toStrictEqual(
-                    false
-                );
+                expect(POSITIVE_INFINITY.equals(nan)).toStrictEqual(false);
             });
         });
         describe("minus zero", () => {
@@ -82,8 +85,8 @@ describe("equals", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.equals(one)).toStrictEqual(false);
             });

--- a/tests/Decimal/exponent.test.js
+++ b/tests/Decimal/exponent.test.js
@@ -1,10 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+} from "./special-values.js";
 
 describe("exponent", () => {
     describe("NaN", () => {
         test("throws", () => {
-            expect(() => new Decimal("NaN").exponent()).toThrow(RangeError);
-            expect(() => new Decimal("NaN").exponent()).toThrow(
+            expect(() => NAN.exponent()).toThrow(RangeError);
+            expect(() => NAN.exponent()).toThrow(
                 "Cannot determine exponent for NaN"
             );
         });
@@ -12,18 +18,14 @@ describe("exponent", () => {
 
     describe("infinity", () => {
         test("positive throws", () => {
-            expect(() => new Decimal("Infinity").exponent()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").exponent()).toThrow(
+            expect(() => POSITIVE_INFINITY.exponent()).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.exponent()).toThrow(
                 "Cannot determine exponent for an infinite value"
             );
         });
         test("negative throws", () => {
-            expect(() => new Decimal("-Infinity").exponent()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("-Infinity").exponent()).toThrow(
+            expect(() => NEGATIVE_INFINITY.exponent()).toThrow(RangeError);
+            expect(() => NEGATIVE_INFINITY.exponent()).toThrow(
                 "Cannot determine exponent for an infinite value"
             );
         });
@@ -37,7 +39,7 @@ describe("exponent", () => {
             expect(new Decimal("4.2").exponent()).toStrictEqual(0);
         });
         test("zero", () => {
-            expect(new Decimal("0").exponent()).toStrictEqual(-6143);
+            expect(POSITIVE_ZERO.exponent()).toStrictEqual(-6143);
         });
         test("simple number, greater than 10, with exponent apparently at limit", () => {
             expect(new Decimal("42E-6143").exponent()).toStrictEqual(-6142);

--- a/tests/Decimal/greaterhan.test.js
+++ b/tests/Decimal/greaterhan.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("greaterThan", () => {
@@ -86,8 +93,8 @@ describe("greaterThan", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.greaterThan(one)).toStrictEqual(true);
             });

--- a/tests/Decimal/greaterthanorequal.test.js
+++ b/tests/Decimal/greaterthanorequal.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("greaterThanOrEqual", () => {
@@ -90,8 +97,8 @@ describe("greaterThanOrEqual", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.greaterThanOrEqual(one)).toStrictEqual(true);
             });

--- a/tests/Decimal/isfinite.test.js
+++ b/tests/Decimal/isfinite.test.js
@@ -1,22 +1,29 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 describe("isFinite", () => {
     test("42", () => {
         expect(new Decimal("42").isFinite()).toStrictEqual(true);
     });
     test("0", () => {
-        expect(new Decimal("0").isFinite()).toStrictEqual(true);
+        expect(POSITIVE_ZERO.isFinite()).toStrictEqual(true);
     });
     test("-0", () => {
-        expect(new Decimal("-0").isFinite()).toStrictEqual(true);
+        expect(NEGATIVE_ZERO.isFinite()).toStrictEqual(true);
     });
     test("Infinity", () => {
-        expect(new Decimal("Infinity").isFinite()).toStrictEqual(false);
+        expect(POSITIVE_INFINITY.isFinite()).toStrictEqual(false);
     });
     test("-Infinity", () => {
-        expect(new Decimal("-Infinity").isFinite()).toStrictEqual(false);
+        expect(NEGATIVE_INFINITY.isFinite()).toStrictEqual(false);
     });
     test("NaN", () => {
-        expect(new Decimal("NaN").isFinite()).toStrictEqual(false);
+        expect(NAN.isFinite()).toStrictEqual(false);
     });
 });

--- a/tests/Decimal/isnormal.test.js
+++ b/tests/Decimal/isnormal.test.js
@@ -1,28 +1,30 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+} from "./special-values.js";
 
 describe("isNormal", () => {
     describe("NaN", () => {
         test("throws", () => {
-            expect(() => new Decimal("NaN").isNormal()).toThrow(RangeError);
-            expect(() => new Decimal("NaN").isNormal()).toThrow(
+            expect(() => NAN.isNormal()).toThrow(RangeError);
+            expect(() => NAN.isNormal()).toThrow(
                 "Cannot determine whether NaN is normal"
             );
         });
     });
     describe("infinity", () => {
         test("positive throws", () => {
-            expect(() => new Decimal("Infinity").isNormal()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").isNormal()).toThrow(
+            expect(() => POSITIVE_INFINITY.isNormal()).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.isNormal()).toThrow(
                 "Only finite numbers can be said to be normal or not"
             );
         });
         test("negative throws", () => {
-            expect(() => new Decimal("-Infinity").isNormal()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("-Infinity").isNormal()).toThrow(
+            expect(() => NEGATIVE_INFINITY.isNormal()).toThrow(RangeError);
+            expect(() => NEGATIVE_INFINITY.isNormal()).toThrow(
                 "Only finite numbers can be said to be normal or not"
             );
         });
@@ -32,8 +34,8 @@ describe("isNormal", () => {
             expect(new Decimal("42").isNormal()).toStrictEqual(true);
         });
         test("zero is not normal", () => {
-            expect(() => new Decimal("0").isNormal()).toThrow(RangeError);
-            expect(() => new Decimal("0").isNormal()).toThrow(
+            expect(() => POSITIVE_ZERO.isNormal()).toThrow(RangeError);
+            expect(() => POSITIVE_ZERO.isNormal()).toThrow(
                 "Only non-zero numbers can be said to be normal or not"
             );
         });

--- a/tests/Decimal/issubnormal.test.js
+++ b/tests/Decimal/issubnormal.test.js
@@ -1,10 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+} from "./special-values.js";
 
 describe("isSubnormal", () => {
     describe("NaN", () => {
         test("throws", () => {
-            expect(() => new Decimal("NaN").isSubnormal()).toThrow(RangeError);
-            expect(() => new Decimal("NaN").isSubnormal()).toThrow(
+            expect(() => NAN.isSubnormal()).toThrow(RangeError);
+            expect(() => NAN.isSubnormal()).toThrow(
                 "Cannot determine whether NaN is subnormal"
             );
         });
@@ -12,18 +18,14 @@ describe("isSubnormal", () => {
 
     describe("infinity", () => {
         test("positive throws", () => {
-            expect(() => new Decimal("Infinity").isSubnormal()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").isSubnormal()).toThrow(
+            expect(() => POSITIVE_INFINITY.isSubnormal()).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.isSubnormal()).toThrow(
                 "Only finite numbers can be said to be subnormal or not"
             );
         });
         test("negative throws", () => {
-            expect(() => new Decimal("-Infinity").isSubnormal()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("-Infinity").isSubnormal()).toThrow(
+            expect(() => NEGATIVE_INFINITY.isSubnormal()).toThrow(RangeError);
+            expect(() => NEGATIVE_INFINITY.isSubnormal()).toThrow(
                 "Only finite numbers can be said to be subnormal or not"
             );
         });
@@ -34,7 +36,7 @@ describe("isSubnormal", () => {
             expect(new Decimal("42").isSubnormal()).toStrictEqual(false);
         });
         test("zero is not subnormal", () => {
-            expect(new Decimal("0").isSubnormal()).toStrictEqual(false);
+            expect(POSITIVE_ZERO.isSubnormal()).toStrictEqual(false);
         });
         test("simple number with exponent at limit", () => {
             expect(new Decimal("42E-6144").isSubnormal()).toStrictEqual(false);

--- a/tests/Decimal/iszero.test.js
+++ b/tests/Decimal/iszero.test.js
@@ -1,26 +1,33 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 describe("isZero", () => {
     test("0", () => {
-        expect(new Decimal("0").isZero()).toStrictEqual(true);
+        expect(POSITIVE_ZERO.isZero()).toStrictEqual(true);
     });
     test("0.00", () => {
         expect(new Decimal("0.00").isZero()).toStrictEqual(true);
     });
     test("-0", () => {
-        expect(new Decimal("-0").isZero()).toStrictEqual(true);
+        expect(NEGATIVE_ZERO.isZero()).toStrictEqual(true);
     });
     test("-0.0", () => {
         expect(new Decimal("-0.0").isZero()).toStrictEqual(true);
     });
     test("Infinity", () => {
-        expect(new Decimal("Infinity").isZero()).toStrictEqual(false);
+        expect(POSITIVE_INFINITY.isZero()).toStrictEqual(false);
     });
     test("-Infinity", () => {
-        expect(new Decimal("-Infinity").isZero()).toStrictEqual(false);
+        expect(NEGATIVE_INFINITY.isZero()).toStrictEqual(false);
     });
     test("NaN", () => {
-        expect(new Decimal("NaN").isZero()).toStrictEqual(false);
+        expect(NAN.isZero()).toStrictEqual(false);
     });
     test("42", () => {
         expect(new Decimal("42").isZero()).toStrictEqual(false);

--- a/tests/Decimal/lessthan.test.js
+++ b/tests/Decimal/lessthan.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("lessThan", () => {
@@ -91,8 +98,8 @@ describe("lessThan", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.lessThan(one)).toStrictEqual(false);
             });

--- a/tests/Decimal/lessthanorequal.test.js
+++ b/tests/Decimal/lessthanorequal.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("lessThanOrEqual", () => {
@@ -93,8 +100,8 @@ describe("lessThanOrEqual", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.lessThanOrEqual(one)).toStrictEqual(false);
             });

--- a/tests/Decimal/mantissa.test.js
+++ b/tests/Decimal/mantissa.test.js
@@ -1,9 +1,10 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import { POSITIVE_ZERO, NEGATIVE_ZERO } from "./special-values.js";
 
 describe("mantissa", () => {
     test("0", () => {
-        expect(() => new Decimal("0").mantissa()).toThrow(RangeError);
-        expect(() => new Decimal("0").mantissa()).toThrow(
+        expect(() => POSITIVE_ZERO.mantissa()).toThrow(RangeError);
+        expect(() => POSITIVE_ZERO.mantissa()).toThrow(
             "Zero does not have a mantissa"
         );
     });
@@ -11,7 +12,7 @@ describe("mantissa", () => {
         expect(() => new Decimal("0.0").mantissa()).toThrow(RangeError);
     });
     test("-0", () => {
-        expect(() => new Decimal("-0").mantissa()).toThrow(RangeError);
+        expect(() => NEGATIVE_ZERO.mantissa()).toThrow(RangeError);
     });
     let data = [
         ["123.456", "1.23456", 2],

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -1,7 +1,14 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
-let posZero = new Decimal("0");
-let negZero = new Decimal("-0");
+let posZero = POSITIVE_ZERO;
+let negZero = NEGATIVE_ZERO;
 
 const examples = [
     ["123.456", "789.789", "97504.190784"],
@@ -104,98 +111,80 @@ describe("multiply", () => {
     });
     describe("NaN", () => {
         test("NaN times NaN is NaN", () => {
-            expect(
-                new Decimal("NaN").multiply(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.multiply(NAN).toString()).toStrictEqual("NaN");
         });
         test("number times NaN is NaN", () => {
-            expect(
-                new Decimal("1").multiply(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(new Decimal("1").multiply(NAN).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("NaN times number is NaN", () => {
-            expect(
-                new Decimal("NaN").multiply(new Decimal("1")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.multiply(new Decimal("1")).toString()).toStrictEqual(
+                "NaN"
+            );
         });
     });
     describe("infinity", () => {
         describe("invalid operation", () => {
             test("zero times positive infinity is NaN", () => {
                 expect(
-                    new Decimal("0")
-                        .multiply(new Decimal("Infinity"))
-                        .toString()
+                    POSITIVE_ZERO.multiply(POSITIVE_INFINITY).toString()
                 ).toStrictEqual("NaN");
                 expect(
-                    new Decimal("Infinity")
-                        .multiply(new Decimal("0"))
-                        .toString()
+                    POSITIVE_INFINITY.multiply(POSITIVE_ZERO).toString()
                 ).toStrictEqual("NaN");
             });
             test("zero times negative infinity is NaN", () => {
                 expect(
-                    new Decimal("0")
-                        .multiply(new Decimal("-Infinity"))
-                        .toString()
+                    POSITIVE_ZERO.multiply(NEGATIVE_INFINITY).toString()
                 ).toStrictEqual("NaN");
                 expect(
-                    new Decimal("-Infinity")
-                        .multiply(new Decimal("0"))
-                        .toString()
+                    NEGATIVE_INFINITY.multiply(POSITIVE_ZERO).toString()
                 ).toStrictEqual("NaN");
             });
         });
         test("positive infinity times positive number is positive infinity", () => {
             expect(
-                new Decimal("Infinity").multiply(new Decimal("42")).toString()
+                POSITIVE_INFINITY.multiply(new Decimal("42")).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive number times positive infinity is positive infinity", () => {
             expect(
-                new Decimal("42").multiply(new Decimal("Infinity")).toString()
+                new Decimal("42").multiply(POSITIVE_INFINITY).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive infinity times negative number is negative infinity", () => {
             expect(
-                new Decimal("Infinity").multiply(new Decimal("-42")).toString()
+                POSITIVE_INFINITY.multiply(new Decimal("-42")).toString()
             ).toStrictEqual("-Infinity");
         });
         test("negative number times positive infinity is negative infinity", () => {
             expect(
-                new Decimal("-42").multiply(new Decimal("Infinity")).toString()
+                new Decimal("-42").multiply(POSITIVE_INFINITY).toString()
             ).toStrictEqual("-Infinity");
         });
         test("positive infinity times negative infinity is negative infinity", () => {
             expect(
-                new Decimal("Infinity")
-                    .multiply(new Decimal("-Infinity"))
-                    .toString()
+                POSITIVE_INFINITY.multiply(NEGATIVE_INFINITY).toString()
             ).toStrictEqual("-Infinity");
         });
         test("positive infinity times positive infinity is positive infinity", () => {
             expect(
-                new Decimal("Infinity")
-                    .multiply(new Decimal("Infinity"))
-                    .toString()
+                POSITIVE_INFINITY.multiply(POSITIVE_INFINITY).toString()
             ).toStrictEqual("Infinity");
         });
         test("negative infinity times negative infinity is positive infinity", () => {
             expect(
-                new Decimal("-Infinity")
-                    .multiply(new Decimal("-Infinity"))
-                    .toString()
+                NEGATIVE_INFINITY.multiply(NEGATIVE_INFINITY).toString()
             ).toStrictEqual("Infinity");
         });
         test("negative infinity times positive infinity is negative infinity", () => {
             expect(
-                new Decimal("-Infinity")
-                    .multiply(new Decimal("Infinity"))
-                    .toString()
+                NEGATIVE_INFINITY.multiply(POSITIVE_INFINITY).toString()
             ).toStrictEqual("-Infinity");
         });
-        let negInf = new Decimal("-Infinity");
-        let posInf = new Decimal("Infinity");
+        let negInf = NEGATIVE_INFINITY;
+        let posInf = POSITIVE_INFINITY;
         test("negative infinity times itself", () => {
             expect(negInf.multiply(negInf).toString()).toStrictEqual(
                 "Infinity"
@@ -226,7 +215,7 @@ describe("multiply", () => {
         });
         test("example four", () => {
             expect(
-                new Decimal("0.9").multiply(new Decimal("-0")).toString()
+                new Decimal("0.9").multiply(NEGATIVE_ZERO).toString()
             ).toStrictEqual("-0"); // would be -0.0 in official IEEE 754
         });
         test("example five", () => {

--- a/tests/Decimal/negate.test.js
+++ b/tests/Decimal/negate.test.js
@@ -1,17 +1,24 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
 
 describe("negate", () => {
     test("minus zero", () => {
-        expect(new Decimal("-0").negate().toString()).toStrictEqual("0");
+        expect(NEGATIVE_ZERO.negate().toString()).toStrictEqual("0");
     });
     test("zero", () => {
-        expect(new Decimal("0").negate().toString()).toStrictEqual("-0");
+        expect(POSITIVE_ZERO.negate().toString()).toStrictEqual("-0");
     });
     test("NaN", () => {
-        expect(new Decimal("NaN").negate().toString()).toStrictEqual("NaN");
+        expect(NAN.negate().toString()).toStrictEqual("NaN");
     });
     test("negative number", () => {
         expect(new Decimal("-42.51").negate().toString()).toStrictEqual(
@@ -29,12 +36,10 @@ describe("negate", () => {
         );
     });
     test("-Infinity", () => {
-        expect(new Decimal("-Infinity").negate().toString()).toStrictEqual(
-            "Infinity"
-        );
+        expect(NEGATIVE_INFINITY.negate().toString()).toStrictEqual("Infinity");
     });
     test("Infinity", () => {
-        expect(new Decimal("Infinity").negate().toString()).toStrictEqual(
+        expect(POSITIVE_INFINITY.negate().toString()).toStrictEqual(
             "-Infinity"
         );
     });

--- a/tests/Decimal/notequals.test.js
+++ b/tests/Decimal/notequals.test.js
@@ -1,9 +1,16 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
-const nan = new Decimal("NaN");
-const zero = new Decimal("0");
-const negZero = new Decimal("-0");
+const nan = NAN;
+const zero = POSITIVE_ZERO;
+const negZero = NEGATIVE_ZERO;
 const one = new Decimal("1");
 
 describe("notEquals", () => {
@@ -76,8 +83,8 @@ describe("notEquals", () => {
             });
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test("positive infinity vs number", () => {
                 expect(posInf.notEquals(one)).toStrictEqual(true);
             });

--- a/tests/Decimal/remainder.test.js
+++ b/tests/Decimal/remainder.test.js
@@ -1,4 +1,11 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 const a = "4.1";
 const b = "1.25";
@@ -26,12 +33,12 @@ describe("remainder", () => {
     });
     test("divide by zero", () => {
         expect(
-            new Decimal("42").remainder(new Decimal("0")).toString()
+            new Decimal("42").remainder(POSITIVE_ZERO).toString()
         ).toStrictEqual("NaN");
     });
     test("divide by minus zero", () => {
         expect(
-            new Decimal("42").remainder(new Decimal("-0")).toString()
+            new Decimal("42").remainder(NEGATIVE_ZERO).toString()
         ).toStrictEqual("NaN");
     });
     test("cleanly divides", () => {
@@ -41,7 +48,7 @@ describe("remainder", () => {
     });
     test("negative zero dividend keeps its sign", () => {
         expect(
-            new Decimal("-0").remainder(new Decimal("1")).toString()
+            NEGATIVE_ZERO.remainder(new Decimal("1")).toString()
         ).toStrictEqual("-0");
     });
     describe("an exact-zero remainder keeps the dividend's sign", () => {
@@ -58,24 +65,22 @@ describe("remainder", () => {
     });
     describe("NaN", () => {
         test("NaN remainder NaN is NaN", () => {
-            expect(
-                new Decimal("NaN").remainder(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.remainder(NAN).toString()).toStrictEqual("NaN");
         });
         test("number remainder NaN is NaN", () => {
-            expect(
-                new Decimal("1").remainder(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(new Decimal("1").remainder(NAN).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("NaN remainder number is NaN", () => {
-            expect(
-                new Decimal("NaN").remainder(new Decimal("1")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.remainder(new Decimal("1")).toString()).toStrictEqual(
+                "NaN"
+            );
         });
     });
     describe("infinity", () => {
-        let posInf = new Decimal("Infinity");
-        let negInf = new Decimal("-Infinity");
+        let posInf = POSITIVE_INFINITY;
+        let negInf = NEGATIVE_INFINITY;
         test("positive infinity remainder positive infinity is NaN", () => {
             expect(posInf.remainder(posInf).toString()).toStrictEqual("NaN");
         });

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -1,4 +1,11 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 import { expectDecimal128 } from "./util.js";
 
 const ROUNDING_MODE_CEILING = "ceil";
@@ -239,11 +246,11 @@ describe("round", () => {
             });
         });
         test("NaN", () => {
-            expect(new Decimal("NaN").round().toString()).toStrictEqual("NaN");
+            expect(NAN.round().toString()).toStrictEqual("NaN");
         });
         describe("infinity", () => {
-            let posInf = new Decimal("Infinity");
-            let negInf = new Decimal("-Infinity");
+            let posInf = POSITIVE_INFINITY;
+            let negInf = NEGATIVE_INFINITY;
             test(`positive infinity (no argument)`, () => {
                 expect(posInf.round().toString()).toStrictEqual("Infinity");
             });
@@ -290,19 +297,17 @@ describe("round", () => {
             ).toStrictEqual("123");
         });
         test("NaN", () => {
-            expect(
-                new Decimal("NaN").round(0, "ceil").toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.round(0, "ceil").toString()).toStrictEqual("NaN");
         });
         test("positive infinity", () => {
-            expect(
-                new Decimal("Infinity").round(0, "ceil").toString()
-            ).toStrictEqual("Infinity");
+            expect(POSITIVE_INFINITY.round(0, "ceil").toString()).toStrictEqual(
+                "Infinity"
+            );
         });
         test("minus infinity", () => {
-            expect(
-                new Decimal("-Infinity").round(0, "ceil").toString()
-            ).toStrictEqual("-Infinity");
+            expect(NEGATIVE_INFINITY.round(0, "ceil").toString()).toStrictEqual(
+                "-Infinity"
+            );
         });
     });
 
@@ -324,21 +329,19 @@ describe("round", () => {
                 expectDecimal128(new Decimal("0.00765").round(0, "trunc"), "0");
             });
             test("NaN", () => {
-                expect(
-                    new Decimal("NaN").round(0, "trunc").toString()
-                ).toStrictEqual("NaN");
+                expect(NAN.round(0, "trunc").toString()).toStrictEqual("NaN");
             });
         });
 
         describe("infinity", () => {
             test("positive infinity", () => {
                 expect(
-                    new Decimal("Infinity").round(0, "trunc").toString()
+                    POSITIVE_INFINITY.round(0, "trunc").toString()
                 ).toStrictEqual("Infinity");
             });
             test("negative infinity", () => {
                 expect(
-                    new Decimal("-Infinity").round(0, "trunc").toString()
+                    NEGATIVE_INFINITY.round(0, "trunc").toString()
                 ).toStrictEqual("-Infinity");
             });
         });
@@ -361,23 +364,21 @@ describe("round", () => {
             ).toStrictEqual("123");
         });
         test("floor of zero is unchanged", () => {
-            expect(new Decimal("0").round(0, "floor").toString()).toStrictEqual(
+            expect(POSITIVE_ZERO.round(0, "floor").toString()).toStrictEqual(
                 "0"
             );
         });
         test("NaN", () => {
-            expect(
-                new Decimal("NaN").round(0, "floor").toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.round(0, "floor").toString()).toStrictEqual("NaN");
         });
         test("positive infinity", () => {
             expect(
-                new Decimal("Infinity").round(0, "floor").toString()
+                POSITIVE_INFINITY.round(0, "floor").toString()
             ).toStrictEqual("Infinity");
         });
         test("minus infinity", () => {
             expect(
-                new Decimal("-Infinity").round(0, "floor").toString()
+                NEGATIVE_INFINITY.round(0, "floor").toString()
             ).toStrictEqual("-Infinity");
         });
     });
@@ -519,7 +520,7 @@ describe("round", () => {
 
         describe("special rounding cases", () => {
             test("round negative zero", () => {
-                const negZero = new Decimal("-0");
+                const negZero = NEGATIVE_ZERO;
                 expect(negZero.round().toString()).toStrictEqual("-0");
                 expect(negZero.round(5).toString()).toStrictEqual("-0");
             });

--- a/tests/Decimal/scale10.test.js
+++ b/tests/Decimal/scale10.test.js
@@ -1,17 +1,21 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+} from "./special-values.js";
 
 describe("scale10", () => {
     describe("NaN", () => {
         test("throws", () => {
-            expect(() => new Decimal("NaN").scale10(5)).toThrow(RangeError);
-            expect(() => new Decimal("NaN").scale10(5)).toThrow(
-                "NaN cannot be scaled"
-            );
+            expect(() => NAN.scale10(5)).toThrow(RangeError);
+            expect(() => NAN.scale10(5)).toThrow("NaN cannot be scaled");
         });
     });
     describe("simple examples", () => {
         test("0", () => {
-            expect(new Decimal("0").scale10(4).toString()).toStrictEqual("0");
+            expect(POSITIVE_ZERO.scale10(4).toString()).toStrictEqual("0");
         });
         test("42, 4", () => {
             expect(new Decimal("42").scale10(4).toString()).toStrictEqual(
@@ -35,17 +39,13 @@ describe("scale10", () => {
     });
     describe("infinty", () => {
         test("positive infinity throws", () => {
-            expect(() => new Decimal("Infinity").scale10(5)).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").scale10(5)).toThrow(
+            expect(() => POSITIVE_INFINITY.scale10(5)).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.scale10(5)).toThrow(
                 "Infinity cannot be scaled"
             );
         });
         test("negative infinity throws", () => {
-            expect(() => new Decimal("-Infinity").scale10(5)).toThrow(
-                RangeError
-            );
+            expect(() => NEGATIVE_INFINITY.scale10(5)).toThrow(RangeError);
         });
     });
 });

--- a/tests/Decimal/significand.test.js
+++ b/tests/Decimal/significand.test.js
@@ -1,35 +1,38 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 describe("significand", () => {
     describe("NaN", () => {
         test("throws", () => {
-            expect(() => new Decimal("NaN").significand()).toThrow(RangeError);
-            expect(() => new Decimal("NaN").significand()).toThrow(
+            expect(() => NAN.significand()).toThrow(RangeError);
+            expect(() => NAN.significand()).toThrow(
                 "NaN does not have a scaled significand"
             );
         });
     });
     describe("infinities", () => {
         test("positive throws", () => {
-            expect(() => new Decimal("Infinity").significand()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").significand()).toThrow(
+            expect(() => POSITIVE_INFINITY.significand()).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.significand()).toThrow(
                 "Infinity does not have a scaled significand"
             );
         });
         test("negative throws", () => {
-            expect(() => new Decimal("-Infinity").significand()).toThrow(
-                RangeError
-            );
+            expect(() => NEGATIVE_INFINITY.significand()).toThrow(RangeError);
         });
     });
     describe("finite values", () => {
         test("0", () => {
-            expect(new Decimal("0").significand()).toStrictEqual(0n);
+            expect(POSITIVE_ZERO.significand()).toStrictEqual(0n);
         });
         test("-0", () => {
-            expect(new Decimal("-0").significand()).toStrictEqual(0n);
+            expect(NEGATIVE_ZERO.significand()).toStrictEqual(0n);
         });
         test("123.456", () => {
             expect(new Decimal("123.456").significand()).toStrictEqual(123456n);

--- a/tests/Decimal/special-values.js
+++ b/tests/Decimal/special-values.js
@@ -1,0 +1,7 @@
+import { Decimal } from "../../src/Decimal.mjs";
+
+export const NAN = new Decimal("NaN");
+export const POSITIVE_INFINITY = new Decimal("Infinity");
+export const NEGATIVE_INFINITY = new Decimal("-Infinity");
+export const POSITIVE_ZERO = new Decimal("0");
+export const NEGATIVE_ZERO = new Decimal("-0");

--- a/tests/Decimal/special-values.test.js
+++ b/tests/Decimal/special-values.test.js
@@ -1,0 +1,25 @@
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
+
+describe("special-value constants", () => {
+    test("NAN is NaN", () => {
+        expect(NAN.toString()).toStrictEqual("NaN");
+    });
+    test("POSITIVE_INFINITY is Infinity", () => {
+        expect(POSITIVE_INFINITY.toString()).toStrictEqual("Infinity");
+    });
+    test("NEGATIVE_INFINITY is -Infinity", () => {
+        expect(NEGATIVE_INFINITY.toString()).toStrictEqual("-Infinity");
+    });
+    test("POSITIVE_ZERO is 0", () => {
+        expect(POSITIVE_ZERO.toString()).toStrictEqual("0");
+    });
+    test("NEGATIVE_ZERO is -0", () => {
+        expect(NEGATIVE_ZERO.toString()).toStrictEqual("-0");
+    });
+});

--- a/tests/Decimal/subtract.test.js
+++ b/tests/Decimal/subtract.test.js
@@ -1,4 +1,11 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 import { expectDecimal128 } from "./util.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
@@ -39,24 +46,22 @@ describe("subtract", () => {
     });
     describe("NaN", () => {
         test("NaN minus NaN is NaN", () => {
-            expect(
-                new Decimal("NaN").subtract(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.subtract(NAN).toString()).toStrictEqual("NaN");
         });
         test("NaN minus number", () => {
-            expect(
-                new Decimal("NaN").subtract(new Decimal("1")).toString()
-            ).toStrictEqual("NaN");
+            expect(NAN.subtract(new Decimal("1")).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("number minus NaN", () => {
-            expect(
-                new Decimal("1").subtract(new Decimal("NaN")).toString()
-            ).toStrictEqual("NaN");
+            expect(new Decimal("1").subtract(NAN).toString()).toStrictEqual(
+                "NaN"
+            );
         });
     });
     describe("zero", () => {
         let d = new Decimal("42.65");
-        let zero = new Decimal("0");
+        let zero = POSITIVE_ZERO;
         test("difference is zero", () => {
             expect(d.subtract(d).toString()).toStrictEqual("0");
         });
@@ -69,15 +74,15 @@ describe("subtract", () => {
     });
     describe("minus zero", () => {
         let x = new Decimal("42.54");
-        let minusZero = new Decimal("-0");
+        let minusZero = NEGATIVE_ZERO;
         test("subtracting minus zero", () => {
             expect(x.subtract(minusZero).toString()).toStrictEqual("42.54");
         });
     });
 
     describe("infinity", () => {
-        let posInf = new Decimal("Infinity");
-        let negInf = new Decimal("-Infinity");
+        let posInf = POSITIVE_INFINITY;
+        let negInf = NEGATIVE_INFINITY;
         describe("first argument", () => {
             describe("positive infinity", () => {
                 test("positive number", () => {

--- a/tests/Decimal/tobigint.test.js
+++ b/tests/Decimal/tobigint.test.js
@@ -1,10 +1,17 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 
 describe("toBigInt", () => {
     describe("NaN", () => {
         test("does not work", () => {
-            expect(() => new Decimal("NaN").toBigInt()).toThrow(RangeError);
-            expect(() => new Decimal("NaN").toBigInt()).toThrow(
+            expect(() => NAN.toBigInt()).toThrow(RangeError);
+            expect(() => NAN.toBigInt()).toThrow(
                 "NaN cannot be converted to a BigInt"
             );
         });
@@ -12,26 +19,22 @@ describe("toBigInt", () => {
 
     describe("zero", () => {
         test("positive zero", () => {
-            expect(new Decimal("0").toBigInt()).toStrictEqual(0n);
+            expect(POSITIVE_ZERO.toBigInt()).toStrictEqual(0n);
         });
         test("negative zero", () => {
-            expect(new Decimal("-0").toBigInt()).toStrictEqual(0n);
+            expect(NEGATIVE_ZERO.toBigInt()).toStrictEqual(0n);
         });
     });
 
     describe("infinity", () => {
         test("positive", () => {
-            expect(() => new Decimal("Infinity").toBigInt()).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("Infinity").toBigInt()).toThrow(
+            expect(() => POSITIVE_INFINITY.toBigInt()).toThrow(RangeError);
+            expect(() => POSITIVE_INFINITY.toBigInt()).toThrow(
                 "Infinity cannot be converted to a BigInt"
             );
         });
         test("negative", () => {
-            expect(() => new Decimal("-Infinity").toBigInt()).toThrow(
-                RangeError
-            );
+            expect(() => NEGATIVE_INFINITY.toBigInt()).toThrow(RangeError);
         });
     });
 

--- a/tests/Decimal/tonumber.test.js
+++ b/tests/Decimal/tonumber.test.js
@@ -1,28 +1,33 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import {
+    NAN,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    POSITIVE_ZERO,
+    NEGATIVE_ZERO,
+} from "./special-values.js";
 import { expectDecimal128 } from "./util.js";
 
 describe("toNumber", () => {
     describe("NaN", () => {
         test("works", () => {
-            expect(new Decimal("NaN").toNumber()).toStrictEqual(NaN);
+            expect(NAN.toNumber()).toStrictEqual(NaN);
         });
     });
     describe("zero", () => {
         test("positive zero", () => {
-            expect(new Decimal("0").toNumber()).toStrictEqual(0);
+            expect(POSITIVE_ZERO.toNumber()).toStrictEqual(0);
         });
         test("negative zero", () => {
-            expect(new Decimal("-0").toNumber()).toStrictEqual(-0);
+            expect(NEGATIVE_ZERO.toNumber()).toStrictEqual(-0);
         });
     });
     describe("infinity", () => {
         test("positive infinity", () => {
-            expect(new Decimal("Infinity").toNumber()).toStrictEqual(Infinity);
+            expect(POSITIVE_INFINITY.toNumber()).toStrictEqual(Infinity);
         });
         test("negative infinity", () => {
-            expect(new Decimal("-Infinity").toNumber()).toStrictEqual(
-                -Infinity
-            );
+            expect(NEGATIVE_INFINITY.toNumber()).toStrictEqual(-Infinity);
         });
     });
     describe("simple examples", () => {


### PR DESCRIPTION
Adds a dedicated `tests/Decimal/special-values.js` module exporting `NAN`, `POSITIVE_INFINITY`, `NEGATIVE_INFINITY`, `POSITIVE_ZERO`, and `NEGATIVE_ZERO` as shared singletons (safe because `Decimal` is an immutable value type), then migrates the operand and expected-result call sites across the arithmetic, comparison, classification, inspection, and conversion tests to import them instead of re-constructing the same string literals. Parsing and serialization tests (`constructor`, `tostring`, `toexponential`, `tofixed`, `toprecision`) keep their literals, since there the exact input string is the thing under test.