### PR TITLE
Compute remainder exactly instead of via a rounded quotient

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -17,7 +17,6 @@ import { CoefficientExponent, formatExponent } from "./CoefficientExponent.mjs";
 import {
     flipModeForNegative,
     ROUNDING_MODE_HALF_EVEN,
-    ROUNDING_MODE_TRUNCATE,
     ROUNDING_MODES,
     type RoundingMode,
 } from "./Rounding.mjs";
@@ -1199,28 +1198,47 @@ export class Decimal {
             return new Decimal(NAN);
         }
 
-        // When |this| < |d| the truncated quotient is zero, so the remainder is
-        // the dividend itself (keeping its sign). Comparing magnitudes lets this
-        // shortcut work for every sign combination without recursing through
-        // negate(). Otherwise, this - d * trunc(this / d) is sign-correct on its
-        // own: signed division, multiplication, and subtraction give the
-        // remainder the dividend's sign for all sign combinations.
-        if (this.abs().compare(d.abs()) === -1) {
+        // A zero dividend is its own remainder, keeping its sign.
+        if (this.isZero()) {
             return this.#clone();
         }
 
-        let q = this.divide(d).round(0, ROUNDING_MODE_TRUNCATE);
-        let r = this.subtract(d.multiply(q));
+        // The remainder is computed exactly: align both operands to a common
+        // quantum and take the bigint remainder of their coefficients. The
+        // identity this - d * trunc(this / d) is not usable here because
+        // divide() rounds the quotient to 34 significant digits: once the
+        // quotient reaches 10^34, the rounding error in its truncated value
+        // makes the "remainder" arbitrarily larger than the divisor.
+        let ourV = this.#d as CoefficientExponent;
+        let theirV = d.#d as CoefficientExponent;
+        let minExp = Math.min(ourV.exponent, theirV.exponent);
+        let ourCoefficient =
+            ourV.coefficient * 10n ** BigInt(ourV.exponent - minExp);
+        let theirCoefficient =
+            theirV.coefficient * 10n ** BigInt(theirV.exponent - minExp);
+        let remainderCoefficient = ourCoefficient % theirCoefficient;
 
-        // A non-zero remainder already carries the dividend's sign (an identity
-        // of truncated division), but an exact-zero remainder comes back as +0
-        // from subtract(). The remainder keeps the dividend's sign even then
-        // (e.g. -1 % 1 is -0), so restore it explicitly.
-        if (r.isZero()) {
+        // The remainder keeps the dividend's sign (an identity of truncated
+        // division) even when it is exactly zero (e.g. -1 % 1 is -0).
+        if (remainderCoefficient === 0n) {
             return new Decimal(this.isNegative() ? "-0" : "0");
         }
 
-        return r;
+        // The exact remainder of two in-range values is itself in range
+        // (writing |this| = X * 10^a and |d| = D * 10^b, either the quotient
+        // is zero and the remainder is |this|, or |this| >= |d| forces
+        // digits(D) + b - min(a, b) <= digits(X) <= 34), so rounding is a
+        // no-op except for operands that already sit below Decimal128's
+        // minimum quantum of 10^-6176.
+        return new Decimal(
+            RoundToDecimal128Domain(
+                new CoefficientExponent(
+                    remainderCoefficient,
+                    minExp,
+                    this.isNegative()
+                )
+            )
+        );
     }
 
     /**

--- a/tests/Decimal/remainder.test.js
+++ b/tests/Decimal/remainder.test.js
@@ -226,9 +226,10 @@ describe("remainder", () => {
             test("remainder where quotient would overflow", () => {
                 const dividend = new Decimal("1E+6144");
                 const divisor = new Decimal("1E-100");
-                // Even though dividend/divisor would overflow, remainder computation fails
+                // The quotient (1E+6244) is not representable, but the
+                // remainder is exact: 1E+6144 is an integer multiple of 1E-100
                 const result = dividend.remainder(divisor);
-                expect(result.toString()).toStrictEqual("-Infinity");
+                expect(result.toString()).toStrictEqual("0");
             });
 
             test("remainder with subnormal values", () => {
@@ -264,9 +265,9 @@ describe("remainder", () => {
             test("cyclic remainder pattern at extreme", () => {
                 const base = new Decimal("1E+6143");
                 const mod3 = new Decimal("3");
-                // 1E+6143 % 3 - the result is very large due to the extreme exponent
+                // 10 ≡ 1 (mod 3), so 1E+6143 ≡ 1 (mod 3)
                 const result = base.remainder(mod3);
-                expect(result.toString()).toStrictEqual("1e+6109");
+                expect(result.toString()).toStrictEqual("1");
             });
 
             test("remainder chain with large values", () => {
@@ -282,6 +283,38 @@ describe("remainder", () => {
                 const mod2 = new Decimal("1E+6143");
                 const remainder2 = remainder1.remainder(mod2);
                 expect(remainder2.lessThan(mod2)).toBe(true);
+            });
+        });
+
+        describe("quotient exceeds 34 significant digits", () => {
+            // The remainder must be exact even when the truncated quotient
+            // is not representable in 34 digits (x - y * trunc(x / y)
+            // computed with a rounded quotient gives garbage).
+            test("1e40 % 7", () => {
+                // 10^40 mod 7 = 3^40 mod 7 = 4
+                expect(
+                    new Decimal("1e40").remainder(new Decimal("7")).toString()
+                ).toStrictEqual("4");
+            });
+
+            test("exact remainder below the minimum quantum rounds to zero", () => {
+                // The exact remainder is 2.3e-6177, below Decimal128's
+                // smallest positive value; it rounds to zero like any other
+                // operation's result would.
+                const x = new Decimal("1.23e-6176");
+                const y = new Decimal("1e-6176");
+                expect(x.remainder(y).toString()).toStrictEqual("0");
+            });
+
+            test("tiny operands with a quotient near 2e100", () => {
+                // Found by pabst (seed 2296663786): the remainder came out
+                // ~10^67 times larger than the divisor, with flipped sign.
+                const x = new Decimal("-5.00158408674736e-50");
+                const y = new Decimal("-2.3030815829730813e-150");
+                const r = x.remainder(y);
+                expect(r.toString()).toStrictEqual("-8.064634468813786e-151");
+                expect(r.abs().lessThan(y.abs())).toBe(true);
+                expect(r.isNegative()).toBe(true);
             });
         });
 


### PR DESCRIPTION
Fixes #103.

`remainder()` used the identity `x - d * trunc(x / d)`, but `divide()` rounds the quotient to 34 significant digits, so once |x / d| reaches 10^34 the "remainder" could exceed the divisor in magnitude by many orders and carry the wrong sign.

Instead, align both operands' coefficients to their smaller quantum exponent and take the bigint remainder of the magnitudes, with the dividend's sign. The exact remainder of two in-range values is always representable in 34 digits (if |x| ≥ |d|, then digits(D) + b − min(a, b) ≤ digits(X) ≤ 34; otherwise the remainder is x itself), so nothing is lost — except for operands already below Decimal128's minimum quantum, which round like any other result (see #102).

Two existing tests asserted the buggy values and are corrected here: `1E+6144 % 1E-100` is `0` (not `-Infinity`), and `1E+6143 % 3` is `1` (not `1e+6109`), since 10 ≡ 1 (mod 3).

Found by pabst on the `pabst-property-annotations` branch (properties `keepsDividendSign` and `staysBelowDivisorMagnitude`, seed 2296663786).