### PR TITLE
Quantize subnormal results at Etiny

### DIFF
--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -59,34 +59,6 @@ function shouldRoundAwayFromZero(
 }
 
 /**
- * Apply a rounding mode to a positive CoefficientExponent value
- * This is an internal helper function corresponding to the spec's abstract operation
- */
-function ApplyRoundingModeToPositive(
-    value: CoefficientExponent,
-    mode: RoundingMode
-): CoefficientExponent {
-    const mLow = value.floor();
-    const fraction = value.subtract(mLow);
-
-    if (fraction.isZero()) {
-        return mLow;
-    }
-
-    const roundUp = shouldRoundAwayFromZero(
-        mode,
-        () => fraction.cmp(new CoefficientExponent(5n, -1, false)),
-        () => mLow.coefficient % 2n === 0n
-    );
-
-    if (roundUp) {
-        return mLow.add(new CoefficientExponent(1n, 0, false));
-    }
-
-    return mLow;
-}
-
-/**
  * Represents a decimal number as coefficient * 10^exponent
  * The coefficient is always non-negative; the sign is stored separately
  */
@@ -158,25 +130,10 @@ export class CoefficientExponent {
      * @returns {CoefficientExponent} A new instance with negated sign
      */
     negate(): CoefficientExponent {
-        if (this.isZero()) {
-            return this;
-        }
         return new CoefficientExponent(
             this._coefficient,
             this._exponent,
             !this._isNegative
-        );
-    }
-
-    /**
-     * Returns the absolute value of this CoefficientExponent.
-     * @returns {CoefficientExponent} A new instance with positive sign
-     */
-    abs(): CoefficientExponent {
-        return new CoefficientExponent(
-            this._coefficient,
-            this._exponent,
-            false
         );
     }
 
@@ -217,9 +174,6 @@ export class CoefficientExponent {
      * @throws {RangeError} If the resulting exponent overflows
      */
     scale10(n: bigint): CoefficientExponent {
-        if (this.isZero()) {
-            return this;
-        }
         const newExponent = this._exponent + Number(n);
         return new CoefficientExponent(
             this._coefficient,
@@ -400,23 +354,6 @@ export class CoefficientExponent {
     }
 
     /**
-     * Gets the floor (largest integer less than or equal to this value).
-     * @returns {CoefficientExponent} The floor value
-     */
-    floor(): CoefficientExponent {
-        // Stryker disable next-line EqualityOperator: exponent 0 produces the same value through the truncation path below (divisor 10^0 = 1)
-        if (this._exponent >= 0) {
-            return this;
-        }
-
-        const fracDigits = -this._exponent;
-        const divisor = 10n ** BigInt(fracDigits);
-        const truncatedCoeff = this._coefficient / divisor;
-
-        return new CoefficientExponent(truncatedCoeff, 0, this._isNegative);
-    }
-
-    /**
      * Checks if this value is an integer.
      * @returns {boolean} True if the value has no fractional part
      */
@@ -551,24 +488,13 @@ export class CoefficientExponent {
         numFractionalDigits: number,
         mode: RoundingMode
     ): CoefficientExponent {
-        // Scale up to have numFractionalDigits after the decimal point
-        const scaled = this.scale10(BigInt(numFractionalDigits));
-
-        // For negative numbers, we work with absolute value and adjust rounding mode
-        if (this._isNegative) {
-            const adjustedMode = flipModeForNegative(mode);
-
-            const absScaled = scaled.abs();
-            const rounded = ApplyRoundingModeToPositive(
-                absScaled,
-                adjustedMode
-            );
-            const result = rounded.scale10(-BigInt(numFractionalDigits));
-            return result.negate();
-        } else {
-            const rounded = ApplyRoundingModeToPositive(scaled, mode);
-            return rounded.scale10(-BigInt(numFractionalDigits));
-        }
+        // Keeping numFractionalDigits fractional digits is rounding at
+        // exponent -numFractionalDigits; roundToExponent applies the mode
+        // to the magnitude, so flip it here for negative values.
+        const adjustedMode = this._isNegative
+            ? flipModeForNegative(mode)
+            : mode;
+        return this.roundToExponent(-numFractionalDigits, adjustedMode);
     }
 
     /**

--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -486,6 +486,62 @@ export class CoefficientExponent {
     }
 
     /**
+     * Rounds to the given exponent (quantum): the result is an integer
+     * multiple of 10^targetExponent. Like roundToSignificantDigits, the
+     * rounding mode is applied to the magnitude; callers handle sign by
+     * flipping the mode for negative values.
+     * @param {number} targetExponent - The exponent to round at
+     * @param {RoundingMode} mode - The rounding mode to use
+     * @returns {CoefficientExponent} The rounded value
+     */
+    roundToExponent(
+        targetExponent: number,
+        mode: RoundingMode
+    ): CoefficientExponent {
+        if (this._exponent >= targetExponent) {
+            return this;
+        }
+
+        const digitsToRemove = targetExponent - this._exponent;
+        const currentDigits = this._coefficient.toString().length;
+
+        if (digitsToRemove < currentDigits) {
+            return this.roundToSignificantDigits(
+                currentDigits - digitsToRemove,
+                mode
+            );
+        }
+
+        // Every significant digit sits below the target exponent, so the
+        // result is either zero or a single unit at the target exponent.
+        // Decide without constructing 10^digitsToRemove, which can be
+        // enormous: with more digits to remove than there are digits, the
+        // magnitude is under a tenth of a unit; with exactly as many,
+        // comparing against half a unit compares two coefficients of the
+        // same length.
+        const roundUp = shouldRoundAwayFromZero(
+            mode,
+            () => {
+                if (digitsToRemove > currentDigits) {
+                    return -1;
+                }
+                const half = 5n * 10n ** BigInt(currentDigits - 1);
+                if (this._coefficient < half) {
+                    return -1;
+                }
+                return this._coefficient === half ? 0 : 1;
+            },
+            () => true // rounding down yields zero, which is even
+        );
+
+        return new CoefficientExponent(
+            roundUp ? 1n : 0n,
+            targetExponent,
+            this._isNegative
+        );
+    }
+
+    /**
      * Rounds to a specified number of fractional digits.
      * @param {number} numFractionalDigits - The number of decimal places to keep
      * @param {RoundingMode} mode - The rounding mode to use

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -28,8 +28,13 @@ const MAX_SIGNIFICANT_DIGITS = 34;
 // The largest adjusted exponent of a finite Decimal128 value (Emax); above it,
 // values round to infinity.
 const ADJUSTED_EXPONENT_MAX = 6144;
-// The adjusted exponent of the smallest subnormal value (Etiny = Emin -
-// (precision - 1)); below it, values round to zero.
+// The smallest quantum exponent of a finite Decimal128 value (Etiny = Emin -
+// (precision - 1)). Unlike Emax, which bounds the position of the *leading*
+// significant digit, Etiny bounds the position of the *trailing* one: every
+// finite Decimal128 value is an integer multiple of 10^Etiny. Results with
+// digits below this quantum are rounded at it, so precision shrinks as the
+// leading digit approaches Etiny (gradual underflow), and values too small to
+// round to a nonzero multiple of 10^Etiny become zero.
 const TINY_EXPONENT_MIN = NORMAL_EXPONENT_MIN - (MAX_SIGNIFICANT_DIGITS - 1);
 
 type NaNValue = "NaN";
@@ -63,42 +68,42 @@ function RoundToDecimal128Domain(
         }
         /* c8 ignore end */
 
-        /* c8 ignore start */
         if (d === "0") {
             return "-0";
         }
-        /* c8 ignore end */
 
         return (d as CoefficientExponent).negate();
     }
 
-    // Reduce precision to fit the significand if needed. Rounding can only
-    // carry the adjusted exponent upward (e.g. 999 -> 1000), never lower it, so
-    // the bounds checks below are exact on the rounded result.
-    const sigDigits = v.coefficient.toString().length;
-    let result = v;
-    // Stryker disable next-line EqualityOperator: rounding an exactly-34-digit coefficient to 34 significant digits is a no-op, so > and >= behave identically here
-    if (sigDigits > MAX_SIGNIFICANT_DIGITS) {
-        result = v.roundToSignificantDigits(MAX_SIGNIFICANT_DIGITS, mode);
-    }
-
     // The adjusted exponent is the power of ten of the leading significant
     // digit.
-    const adjustedExponent =
-        result.exponent + result.coefficient.toString().length - 1;
+    const adjustedExponent = v.exponent + v.coefficient.toString().length - 1;
 
-    // Above the largest finite value, round to infinity.
-    if (adjustedExponent > ADJUSTED_EXPONENT_MAX) {
-        return "Infinity";
-    }
+    // The quantum -- the power of ten of the trailing significant digit -- can
+    // sit no more than 33 places below the leading digit (the 34-digit
+    // precision limit) and never below Etiny. In the subnormal range the
+    // second bound binds, so fewer than 34 digits survive (gradual underflow).
+    const targetQuantum = Math.max(
+        adjustedExponent - (MAX_SIGNIFICANT_DIGITS - 1),
+        TINY_EXPONENT_MIN
+    );
 
-    // Below the smallest subnormal value, round to zero.
-    if (adjustedExponent < TINY_EXPONENT_MIN) {
-        return "0";
-    }
+    // Round once, directly at the target quantum; rounding to 34 significant
+    // digits first and then again at Etiny would double-round. Rounding can
+    // only carry the adjusted exponent upward (e.g. 999 -> 1000), never lower
+    // it, so the overflow check below is exact on the rounded result.
+    const result = v.roundToExponent(targetQuantum, mode);
 
+    // Too small to round to a nonzero multiple of 10^Etiny.
     if (result.isZero()) {
         return "0";
+    }
+
+    // Above the largest finite value, round to infinity.
+    const roundedAdjustedExponent =
+        result.exponent + result.coefficient.toString().length - 1;
+    if (roundedAdjustedExponent > ADJUSTED_EXPONENT_MAX) {
+        return "Infinity";
     }
 
     return result;

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -31,10 +31,7 @@ const ADJUSTED_EXPONENT_MAX = 6144;
 // The smallest quantum exponent of a finite Decimal128 value (Etiny = Emin -
 // (precision - 1)). Unlike Emax, which bounds the position of the *leading*
 // significant digit, Etiny bounds the position of the *trailing* one: every
-// finite Decimal128 value is an integer multiple of 10^Etiny. Results with
-// digits below this quantum are rounded at it, so precision shrinks as the
-// leading digit approaches Etiny (gradual underflow), and values too small to
-// round to a nonzero multiple of 10^Etiny become zero.
+// finite Decimal128 value is an integer multiple of 10^Etiny.
 const TINY_EXPONENT_MIN = NORMAL_EXPONENT_MIN - (MAX_SIGNIFICANT_DIGITS - 1);
 
 type NaNValue = "NaN";
@@ -62,11 +59,9 @@ function RoundToDecimal128Domain(
 
         let d = RoundToDecimal128Domain(v.negate(), reverseRoundingMode);
 
-        /* c8 ignore start */
         if (d === "Infinity") {
             return "-Infinity";
         }
-        /* c8 ignore end */
 
         if (d === "0") {
             return "-0";

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -119,10 +119,12 @@ describe("constructor", () => {
             );
         });
         test("min exponent", () => {
-            // 123E-6177 = 1.23E-6175, a subnormal whose adjusted exponent
-            // (-6175) is reported truthfully rather than clamped to Emin.
+            // 123E-6177 = 1.23E-6175, a subnormal whose trailing digit sits
+            // below the Etiny quantum (10^-6176) and so gets rounded away;
+            // the adjusted exponent (-6175) is reported truthfully rather
+            // than clamped to Emin.
             expect(new Decimal("123E-6177").toString()).toStrictEqual(
-                "1.23e-6175"
+                "1.2e-6175"
             );
         });
         test("integer too big", () => {
@@ -168,15 +170,101 @@ describe("constructor", () => {
             });
         });
 
-        // Values with adjusted exponent at or below -6177 underflow to zero.
-        describe("underflow to zero at adjusted exponent -6177", () => {
+        // Every finite Decimal128 value is an integer multiple of 10^-6176
+        // (Etiny). A value with digits below that quantum is rounded at
+        // Etiny, keeping fewer significant digits (gradual underflow).
+        describe("rounding at the Etiny quantum", () => {
+            test("digits below Etiny are rounded away", () => {
+                expect(new Decimal("1.23E-6176").toString()).toStrictEqual(
+                    "1e-6176"
+                );
+            });
+            test("rounding at Etiny respects the rounding mode", () => {
+                expect(
+                    new Decimal("1.23E-6176", {
+                        roundingMode: "ceil",
+                    }).toString()
+                ).toStrictEqual("2e-6176");
+            });
+            test("ties at Etiny round to even", () => {
+                expect(new Decimal("1.5E-6176").toString()).toStrictEqual(
+                    "2e-6176"
+                );
+                expect(new Decimal("2.5E-6176").toString()).toStrictEqual(
+                    "2e-6176"
+                );
+            });
+            test("rounding at Etiny can carry into a higher quantum", () => {
+                expect(new Decimal("9.9E-6176").toString()).toStrictEqual(
+                    "1e-6175"
+                );
+            });
+            test("subnormal precision shrinks below 34 digits", () => {
+                // At adjusted exponent -6144, one below Emin, only 33
+                // significant digits fit above Etiny.
+                expect(
+                    new Decimal(
+                        "1.1111111111111111111111111111152444E-6144"
+                    ).toString()
+                ).toStrictEqual("1.11111111111111111111111111111524e-6144");
+            });
+            test("no double rounding through 34 significant digits", () => {
+                // The value is just over half of the smallest subnormal, so
+                // rounding at Etiny gives 1e-6176. Rounding to 34 significant
+                // digits first would give exactly half, which ties to zero.
+                expect(
+                    new Decimal(
+                        "5.00000000000000000000000000000000001E-6177"
+                    ).toString()
+                ).toStrictEqual("1e-6176");
+            });
+        });
+
+        // Values smaller than the smallest subnormal (1E-6176) also round at
+        // Etiny: to zero or to 1E-6176, per the rounding mode.
+        describe("underflow below the smallest subnormal", () => {
             test("adjusted exponent -6176 is finite", () => {
                 expect(new Decimal("1E-6176").toString()).toStrictEqual(
                     "1e-6176"
                 );
             });
-            test("adjusted exponent -6177 underflows to zero", () => {
+            test("a tenth of the smallest subnormal underflows to zero", () => {
                 expect(new Decimal("1E-6177").toString()).toStrictEqual("0");
+            });
+            test("more than half of the smallest subnormal rounds up to it", () => {
+                expect(new Decimal("6E-6177").toString()).toStrictEqual(
+                    "1e-6176"
+                );
+            });
+            test("just under half of the smallest subnormal rounds to zero", () => {
+                expect(new Decimal("4.9E-6177").toString()).toStrictEqual("0");
+            });
+            test("exactly half of the smallest subnormal ties to zero", () => {
+                expect(new Decimal("5E-6177").toString()).toStrictEqual("0");
+            });
+            test("exactly half of the smallest subnormal rounds up under halfExpand", () => {
+                expect(
+                    new Decimal("5E-6177", {
+                        roundingMode: "halfExpand",
+                    }).toString()
+                ).toStrictEqual("1e-6176");
+            });
+            test("ceil rounds any tiny positive value up to the smallest subnormal", () => {
+                expect(
+                    new Decimal("1E-7000", {
+                        roundingMode: "ceil",
+                    }).toString()
+                ).toStrictEqual("1e-6176");
+            });
+            test("floor rounds any tiny negative value to minus the smallest subnormal", () => {
+                expect(
+                    new Decimal("-1E-7000", {
+                        roundingMode: "floor",
+                    }).toString()
+                ).toStrictEqual("-1e-6176");
+            });
+            test("negative underflow gives negative zero", () => {
+                expect(new Decimal("-1E-7000").toString()).toStrictEqual("-0");
             });
         });
     });

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -279,6 +279,16 @@ describe("division", () => {
                 expect(small.divide(large).toString()).toStrictEqual("0");
             });
 
+            test("quotient with digits below Etiny is rounded at Etiny", () => {
+                // The exact quotient is -1.90503701E-6169, whose last digit
+                // sits one place below the Etiny quantum; rounding there
+                // gives -1.905037E-6169.
+                const quotient = new Decimal("-190503701e-6170").divide(
+                    new Decimal("1e7")
+                );
+                expect(quotient.toString()).toStrictEqual("-1.905037e-6169");
+            });
+
             test("divide subnormal by normal", () => {
                 const subnormal = new Decimal("1E-6150");
                 const normal = new Decimal("10");

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -296,6 +296,15 @@ describe("multiply", () => {
                 expect(small1.multiply(small2).toString()).toStrictEqual("-0");
             });
 
+            test("product with digits below Etiny is rounded at Etiny", () => {
+                // The exact product is -1.0008E-6176, whose last digit sits
+                // below the Etiny quantum; rounding there gives -1E-6176.
+                const product = new Decimal("1251e-3090").multiply(
+                    new Decimal("-8e-3090")
+                );
+                expect(product.toString()).toStrictEqual("-1e-6176");
+            });
+
             test("multiply subnormal values", () => {
                 const sub1 = new Decimal("1E-6150");
                 const sub2 = new Decimal("1E+10");

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -397,6 +397,32 @@ describe("round", () => {
         });
     });
 
+    describe("halfEven ties whose even neighbor ends in a trailing zero", () => {
+        test("10.5 rounds down to 10", () => {
+            expect(
+                new Decimal("10.5").round(0, "halfEven").toString()
+            ).toStrictEqual("10");
+        });
+        test("-10.5 rounds up to -10", () => {
+            expect(
+                new Decimal("-10.5").round(0, "halfEven").toString()
+            ).toStrictEqual("-10");
+        });
+        test("1.05 rounds down to 1.0 at one decimal place", () => {
+            expect(
+                new Decimal("1.05").round(1, "halfEven").toString()
+            ).toStrictEqual("1");
+        });
+        test("10.5 rounds down to 10 under the default mode", () => {
+            expect(new Decimal("10.5").round(0).toString()).toStrictEqual("10");
+        });
+        test("30.5 rounds down to 30", () => {
+            expect(
+                new Decimal("30.5").round(0, "halfEven").toString()
+            ).toStrictEqual("30");
+        });
+    });
+
     describe("edge cases for Decimal128 limits", () => {
         describe("rounding at extreme values", () => {
             test("round maximum value", () => {

--- a/tests/Decimal/tofixed.test.js
+++ b/tests/Decimal/tofixed.test.js
@@ -73,6 +73,9 @@ describe("toFixed", () => {
         test("impute precision to an integer", () => {
             expectDecimal128(new Decimal("42").toFixed({ digits: 1 }), "42.0");
         });
+        test("halfEven tie whose even neighbor ends in a trailing zero", () => {
+            expectDecimal128(new Decimal("10.5").toFixed({ digits: 0 }), "10");
+        });
         test("negative number of decimal places throws", () => {
             expect(() => decimalD.toFixed({ digits: -1 })).toThrow(RangeError);
             expect(() => decimalD.toFixed({ digits: -1 })).toThrow(


### PR DESCRIPTION
RoundToDecimal128Domain bounded only the adjusted exponent, treating Etiny as a lower bound on the position of the *leading* significant digit, symmetric to how Emax bounds it from above. But Etiny bounds the *trailing* digit: every finite Decimal128 value is an integer multiple of 10^-6176, and precision shrinks as the leading digit approaches Etiny (gradual underflow). So values like `1.23e-6176` — in range by adjusted exponent, but with a quantum of 10^-6178 — were accepted verbatim, and anything below 10^-6176 was unconditionally zeroed instead of being rounded at Etiny with the ambient rounding mode (e.g. `6e-6177` should round half-even up to `1e-6176`).

The fix rounds once, directly at the target quantum `max(adjusted - 33, Etiny)`, via a new `CoefficientExponent.roundToExponent`; rounding to 34 significant digits first and re-rounding at Etiny would double-round. When every digit falls below the target quantum, the 0-vs-1-ulp decision is made without constructing 10^gap, which for inputs like `1e-1000000000` would be a billion-digit bigint.

Closes #102.