### PR TITLE
Convert to BigInt from the internal representation, not toString()

### DIFF
--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -287,6 +287,16 @@ export class CoefficientExponent {
     }
 
     /**
+     * Converts this value to a BigInt. Only valid for integers: the
+     * coefficient is normalized (no trailing zeros), so an integer
+     * necessarily has a non-negative exponent.
+     * @returns {bigint} This value as a BigInt
+     */
+    toBigInt(): bigint {
+        return this.signedCoefficientAt(0);
+    }
+
+    /**
      * Adds two CoefficientExponent values.
      * @param {CoefficientExponent} other - The value to add
      * @returns {CoefficientExponent} The sum of the two values

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -611,7 +611,16 @@ export class Decimal {
             );
         }
 
-        return BigInt(this.toString());
+        let v = this.#d as FiniteValue;
+
+        if (v === "0" || v === "-0") {
+            return 0n;
+        }
+
+        // The coefficient is normalized (no trailing zeros), so an integer
+        // necessarily has a non-negative exponent.
+        let scaled = v.coefficient * 10n ** BigInt(v.exponent);
+        return v.isNegative ? -scaled : scaled;
     }
 
     /**

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -617,10 +617,7 @@ export class Decimal {
             return 0n;
         }
 
-        // The coefficient is normalized (no trailing zeros), so an integer
-        // necessarily has a non-negative exponent.
-        let scaled = v.coefficient * 10n ** BigInt(v.exponent);
-        return v.isNegative ? -scaled : scaled;
+        return v.toBigInt();
     }
 
     /**

--- a/tests/Decimal/tobigint.test.js
+++ b/tests/Decimal/tobigint.test.js
@@ -63,4 +63,25 @@ describe("toBigInt", () => {
             expect(new Decimal("-123").toBigInt()).toStrictEqual(-123n);
         });
     });
+    describe("large integers", () => {
+        test("10^21 (where toString switches to exponential notation)", () => {
+            expect(new Decimal(10n ** 21n).toBigInt()).toStrictEqual(
+                10n ** 21n
+            );
+        });
+        test("-10^21", () => {
+            expect(new Decimal(-(10n ** 21n)).toBigInt()).toStrictEqual(
+                -(10n ** 21n)
+            );
+        });
+        test("full 34-digit coefficient scaled far above 10^21", () => {
+            let big = BigInt("9".repeat(34)) * 10n ** 100n;
+            expect(new Decimal(big).toBigInt()).toStrictEqual(big);
+        });
+        test("largest power of ten in the Decimal128 range", () => {
+            expect(new Decimal("1e6144").toBigInt()).toStrictEqual(
+                10n ** 6144n
+            );
+        });
+    });
 });


### PR DESCRIPTION
toBigInt() computed `BigInt(this.toString())`. Following `Number.prototype.toString` behavior, `toString()` switches to exponential notation once the exponent reaches 21, and `BigInt()` cannot parse that form — so every in-range integer of 10^21 or more threw a `SyntaxError`, an error type the JSDoc never documents.

Compute the result directly from the internal representation instead: `coefficient * 10n ** BigInt(exponent)`, with the sign applied. No division branch is needed for negative exponents: `CoefficientExponent` normalizes away trailing zeros, so any value that passes the existing `#isInteger()` guard necessarily has a non-negative exponent. Zero is handled explicitly since it is stored as `"0"`/`"-0"` rather than a `CoefficientExponent`.

Fixes #98 (and unblocks #106).