### PR TITLE
Round scale10 results to the Decimal128 domain

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -311,8 +311,14 @@ export class Decimal {
      * Scales this Decimal128 value by 10^n.
      * This operation multiplies the value by 10 raised to the power of n.
      *
+     * The mathematical result is rounded to the Decimal128 domain: results
+     * above the largest finite value overflow to Infinity, results too small
+     * to represent underflow to zero, and subnormal results are quantized
+     * at 10^-6176.
+     *
      * @param {number} n The power of 10 to scale by (must be an integer)
-     * @returns {Decimal} A new Decimal value equal to this * 10^n
+     * @returns {Decimal} A new Decimal value equal to this * 10^n, rounded
+     *   to the Decimal128 domain
      * @throws {RangeError} If this value is NaN
      * @throws {RangeError} If this value is infinite
      * @throws {TypeError} If n is not an integer
@@ -340,7 +346,11 @@ export class Decimal {
             return this.#clone();
         }
 
-        return new Decimal(v.scale10(BigInt(n)));
+        let rounded = RoundToDecimal128Domain(
+            v.scale10(BigInt(n))
+        ) as CoefficientExponent;
+
+        return new Decimal(rounded);
     }
 
     #emitExponential(): string {

--- a/tests/Decimal/scale10.test.js
+++ b/tests/Decimal/scale10.test.js
@@ -48,4 +48,48 @@ describe("scale10", () => {
             expect(() => NEGATIVE_INFINITY.scale10(5)).toThrow(RangeError);
         });
     });
+    describe("results stay in the Decimal128 domain", () => {
+        test("overflow rounds to Infinity", () => {
+            expect(new Decimal("1").scale10(10000).toString()).toStrictEqual(
+                "Infinity"
+            );
+        });
+        test("overflow just past Emax rounds to Infinity", () => {
+            expect(new Decimal("1e6144").scale10(1).toString()).toStrictEqual(
+                "Infinity"
+            );
+        });
+        test("negative overflow rounds to -Infinity", () => {
+            expect(new Decimal("-1").scale10(10000).toString()).toStrictEqual(
+                "-Infinity"
+            );
+        });
+        test("underflow rounds to zero", () => {
+            expect(new Decimal("1").scale10(-10000).toString()).toStrictEqual(
+                "0"
+            );
+        });
+        test("negative underflow rounds to -0", () => {
+            expect(new Decimal("-1").scale10(-10000).toString()).toStrictEqual(
+                "-0"
+            );
+        });
+        test("in-range subnormal result is quantized at Etiny", () => {
+            expect(
+                new Decimal("1.23e-6175").scale10(-1).toString()
+            ).toStrictEqual("1e-6176");
+        });
+        test("quantized subnormal equals the same value built directly", () => {
+            expect(
+                new Decimal("1.23e-6175")
+                    .scale10(-1)
+                    .equals(new Decimal("1.23e-6176"))
+            ).toStrictEqual(true);
+        });
+        test("toBigInt on an overflowed result throws RangeError", () => {
+            expect(() =>
+                new Decimal("1e6144").scale10(1000).toBigInt()
+            ).toThrow(RangeError);
+        });
+    });
 });


### PR DESCRIPTION
Fixes #100.

`scale10` was the one operation that fed an unrounded `CoefficientExponent` directly to the `Decimal` constructor, which skips `RoundToDecimal128Domain` for that input type. Its results could therefore escape the format's domain, and everything downstream then operated on values outside the data model.

This routes the scaled value through `RoundToDecimal128Domain` before construction, the same pattern `add`, `subtract`, `multiply`, `divide`, and `remainder` already follow. That resolves all four facets collected on the issue:

- **Overflow** rounds to `Infinity` per IEEE 754 scaleB semantics: `new Decimal("1").scale10(10000)` is now `Infinity`, not the out-of-range finite `1e+10000`.
- **Underflow** rounds to zero (sign-preserving): `new Decimal("1").scale10(-10000)` is now `0`; the original pabst counterexample `new Decimal("5e-324").scale10(-5853)` likewise underflows to `0`.
- **In-range subnormal results are quantized at Etiny** (the #107 behavior scale10 previously bypassed): `new Decimal("1.23e-6175").scale10(-1)` is now `1e-6176` and compares equal to the same value built via the constructor.
- **The #112 escape hatch is closed**: `new Decimal("1e6144").scale10(1000).toBigInt()` now throws `RangeError` (the result overflows to `Infinity`) instead of returning a 7145-digit bigint.

The JSDoc for `scale10` now documents the domain-rounding behavior.