### PR TITLE
Fix toExponential's digits path: no crash on single-digit mantissas, round instead of truncating

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -574,9 +574,10 @@ export class Decimal {
 
         let s = this.abs().#emitExponential();
 
-        let [lhs, rhsWithEsign] = s.split(/[.]/);
+        let [mantissa, exp] = s.split(/[eE]/);
 
-        let [rhs, exp] = rhsWithEsign.split(/[eE]/);
+        // A single-digit mantissa has no fraction part (e.g. "7e+0").
+        let [lhs, rhs = ""] = mantissa.split(/[.]/);
 
         let p = this.isNegative() ? "-" : "";
 

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -572,20 +572,24 @@ export class Decimal {
             throw new RangeError("Argument must be an integer");
         }
 
-        let s = this.abs().#emitExponential();
-
-        let [mantissa, exp] = s.split(/[eE]/);
-
-        // A single-digit mantissa has no fraction part (e.g. "7e+0").
-        let [lhs, rhs = ""] = mantissa.split(/[.]/);
-
         let p = this.isNegative() ? "-" : "";
 
-        if (rhs.length <= n) {
-            return p + lhs + "." + rhs + "0".repeat(n - rhs.length) + "e" + exp;
+        if (this.isZero()) {
+            return p + "0." + "0".repeat(n) + "e+0";
         }
 
-        return p + lhs + "." + rhs.substring(0, n) + "e" + exp;
+        let m = this.abs().mantissa();
+        let e = this.exponent();
+
+        let rounded = m.round(n);
+
+        if (rounded.exponent() === 1) {
+            // Rounding carried the mantissa out of [1, 10).
+            rounded = rounded.scale10(-1);
+            e += 1;
+        }
+
+        return p + rounded.toFixed({ digits: n }) + formatExponent(e);
     }
 
     #isInteger(): boolean {

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -56,15 +56,15 @@ describe("toExponential", () => {
         expectDecimal128(decimalD.toExponential({ digits: 5 }), "1.23456e+2");
     });
     test("possibly round non-integer part (2)", () => {
-        expectDecimal128(decimalD.toExponential({ digits: 4 }), "1.2345e+2");
+        expectDecimal128(decimalD.toExponential({ digits: 4 }), "1.2346e+2");
     });
-    test("same number of digits as available means no change", () => {
-        expectDecimal128(decimalD.toExponential({ digits: 3 }), "1.234e+2");
+    test("fewer digits requested than available rounds (1)", () => {
+        expectDecimal128(decimalD.toExponential({ digits: 3 }), "1.235e+2");
     });
-    test("cutoff if number has more digits than requested (1)", () => {
+    test("fewer digits requested than available rounds (2)", () => {
         expectDecimal128(decimalD.toExponential({ digits: 2 }), "1.23e+2");
     });
-    test("cutoff if number has more digits than requested (2)", () => {
+    test("fewer digits requested than available rounds (3)", () => {
         expectDecimal128(decimalD.toExponential({ digits: 1 }), "1.2e+2");
     });
     test("zero decimal places throws", () => {
@@ -90,8 +90,48 @@ describe("toExponential", () => {
         let negD = decimalD.negate();
         test("integer part", () => {
             expect(negD.toExponential({ digits: 3 }).toString()).toStrictEqual(
-                "-1.234e+2"
+                "-1.235e+2"
             );
+        });
+    });
+
+    // Excess mantissa digits are rounded (half-even, like toFixed and
+    // toPrecision), not truncated.
+    describe("rounding, not truncation", () => {
+        test("rounds up when the first dropped digit is large", () => {
+            expect(
+                new Decimal("1.789").toExponential({ digits: 1 })
+            ).toStrictEqual("1.8e+0");
+        });
+        test("tie rounds to even (down)", () => {
+            expect(
+                new Decimal("1.25").toExponential({ digits: 1 })
+            ).toStrictEqual("1.2e+0");
+        });
+        test("tie rounds to even (up)", () => {
+            expect(
+                new Decimal("1.35").toExponential({ digits: 1 })
+            ).toStrictEqual("1.4e+0");
+        });
+        test("tie at a later digit rounds to even", () => {
+            expect(
+                new Decimal("1.005").toExponential({ digits: 2 })
+            ).toStrictEqual("1.00e+0");
+        });
+        test("carry renormalizes the mantissa", () => {
+            expect(
+                new Decimal("9.99").toExponential({ digits: 1 })
+            ).toStrictEqual("1.0e+1");
+        });
+        test("negative carry renormalizes the mantissa", () => {
+            expect(
+                new Decimal("-9.99").toExponential({ digits: 1 })
+            ).toStrictEqual("-1.0e+1");
+        });
+        test("negative exponent", () => {
+            expect(
+                new Decimal("0.0001999").toExponential({ digits: 2 })
+            ).toStrictEqual("2.00e-4");
         });
     });
     test("one", () => {

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -142,6 +142,41 @@ describe("toExponential", () => {
         });
     });
 
+    // A single-digit mantissa renders without a fraction part ("7e+0"),
+    // which the digits code path must handle (issue #99).
+    describe("single-digit mantissa with digits requested", () => {
+        test("single digit", () => {
+            expect(new Decimal("7").toExponential({ digits: 2 })).toStrictEqual(
+                "7.00e+0"
+            );
+        });
+        test("zero", () => {
+            expect(new Decimal("0").toExponential({ digits: 3 })).toStrictEqual(
+                "0.000e+0"
+            );
+        });
+        test("negative zero", () => {
+            expect(
+                new Decimal("-0").toExponential({ digits: 3 })
+            ).toStrictEqual("-0.000e+0");
+        });
+        test("negative single digit", () => {
+            expect(
+                new Decimal("-7").toExponential({ digits: 2 })
+            ).toStrictEqual("-7.00e+0");
+        });
+        test("power of ten", () => {
+            expect(
+                new Decimal("100").toExponential({ digits: 2 })
+            ).toStrictEqual("1.00e+2");
+        });
+        test("negative power of ten exponent", () => {
+            expect(
+                new Decimal("0.001").toExponential({ digits: 2 })
+            ).toStrictEqual("1.00e-3");
+        });
+    });
+
     // Subnormal values must expose their true exponent down to Etiny
     // (-6176) rather than being clamped to Emin (-6143).
     describe("subnormal range", () => {


### PR DESCRIPTION
Fixes #99.

Two fixes to `toExponential({ digits })`:

**Crash on single-digit mantissas (#99).** `toExponential({ digits })` threw a `TypeError` whenever the value's mantissa is a single digit — any power of ten, and zero:

```js
new Decimal("7").toExponential({ digits: 2 })
// TypeError: Cannot read properties of undefined (reading 'split')
```

`#emitExponential()` renders such values without a fraction part (`"7e+0"`), and the digits code path split on `"."` and dereferenced the missing right-hand side. Now `new Decimal("7").toExponential({ digits: 2 })` returns `"7.00e+0"` and `new Decimal("0").toExponential({ digits: 3 })` returns `"0.000e+0"`.

**Truncation instead of rounding.** The digits path dropped excess mantissa digits by string truncation (`"123.456"` with `digits: 3` gave `"1.234e+2"`), unlike `toFixed` and `toPrecision`, which round half-even by default. Truncation also can never express the carry case. The mantissa is now rounded to the requested number of fraction digits with the default (half-even) mode, renormalizing back into [1, 10) when rounding carries it to 10:

```js
new Decimal("123.456").toExponential({ digits: 3 }) // "1.235e+2"
new Decimal("9.99").toExponential({ digits: 1 })    // "1.0e+1"
new Decimal("1.25").toExponential({ digits: 1 })    // "1.2e+0" (half-even)
```

The crash was found by the pabst property `Decimal#toExponential` / `honorsRequestedDigits` on the `pabst-property-annotations` branch; the truncation surfaced while fixing it. (Note: the current spec text's `toExponential` takes no `digits` option at all, so this polyfill extension now at least agrees with its `toFixed`/`toPrecision` siblings. Neither of those accepts `roundingMode` yet, though the spec says they should — that's follow-up work.)