### PR TITLE
Give exactly-cancelling sums and differences the IEEE 754 zero sign

### DIFF
--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -16,6 +16,7 @@
 import { CoefficientExponent, formatExponent } from "./CoefficientExponent.mjs";
 import {
     flipModeForNegative,
+    ROUNDING_MODE_FLOOR,
     ROUNDING_MODE_HALF_EVEN,
     ROUNDING_MODES,
     type RoundingMode,
@@ -146,6 +147,13 @@ function handleDecimalNotation(s: string, mode: RoundingMode): Decimal128Value {
     }
 
     return RoundToDecimal128Domain(v, mode);
+}
+
+// IEEE 754-2019, section 6.3: when a sum (or difference) of operands with
+// opposite (or like) signs is exactly zero, the result is +0 in every
+// rounding-direction attribute except roundTowardNegative, where it is -0.
+function exactlyCancelledZero(mode: RoundingMode): Decimal {
+    return new Decimal(mode === ROUNDING_MODE_FLOOR ? "-0" : "0");
 }
 
 export class Decimal {
@@ -869,6 +877,16 @@ export class Decimal {
             return x.#clone();
         }
 
+        if (this.isZero() && x.isZero()) {
+            // IEEE 754-2019, section 6.3: like-signed zeros sum to a zero
+            // of that same sign; oppositely-signed zeros cancel exactly.
+            if (this.#isNegative === x.#isNegative) {
+                return this.#clone();
+            }
+
+            return exactlyCancelledZero(mode);
+        }
+
         if (this.isZero()) {
             return x.#clone();
         }
@@ -882,11 +900,7 @@ export class Decimal {
         let sum = ourCohort.add(theirCohort);
 
         if (sum.isZero()) {
-            if (this.#isNegative) {
-                return new Decimal("-0");
-            }
-
-            return new Decimal("0");
+            return exactlyCancelledZero(mode);
         }
 
         let rounded = RoundToDecimal128Domain(sum, mode) as CoefficientExponent;
@@ -935,6 +949,16 @@ export class Decimal {
             return x.negate();
         }
 
+        if (this.isZero() && x.isZero()) {
+            // IEEE 754-2019, section 6.3: x - (-x) keeps the sign of x, even
+            // for zeros; like-signed zeros cancel exactly.
+            if (this.#isNegative !== x.#isNegative) {
+                return this.#clone();
+            }
+
+            return exactlyCancelledZero(mode);
+        }
+
         if (this.isZero()) {
             return x.negate();
         }
@@ -948,7 +972,7 @@ export class Decimal {
         let difference = ourCohort.subtract(theirCohort);
 
         if (difference.isZero()) {
-            return new Decimal("0");
+            return exactlyCancelledZero(mode);
         }
 
         let rounded = RoundToDecimal128Domain(

--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -22,13 +22,43 @@ describe("addition", () => {
     });
     test("one plus minus one equals zero", () => {
         expect(one.add(minusOne).toString()).toStrictEqual("0");
-        expect(minusOne.add(one).toString()).toStrictEqual("-0");
+        expect(minusOne.add(one).toString()).toStrictEqual("0");
+    });
+    test("exact cancellation is minus zero when rounding toward negative", () => {
+        expect(
+            one.add(minusOne, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("-0");
+        expect(
+            minusOne.add(one, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("-0");
+    });
+    test("zero plus minus zero", () => {
+        expect(zero.add(minusZero).toString()).toStrictEqual("0");
     });
     test("minus zero plus zero", () => {
         expect(minusZero.add(zero).toString()).toStrictEqual("0");
     });
+    test("oppositely signed zeros are minus zero when rounding toward negative", () => {
+        expect(
+            zero.add(minusZero, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("-0");
+        expect(
+            minusZero.add(zero, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("-0");
+    });
+    test("zero plus zero", () => {
+        expect(zero.add(zero).toString()).toStrictEqual("0");
+    });
     test("minus zero plus minus zero", () => {
         expect(minusZero.add(minusZero).toString()).toStrictEqual("-0");
+    });
+    test("like-signed zeros keep their sign even when rounding toward negative", () => {
+        expect(
+            zero.add(zero, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("0");
+        expect(
+            minusZero.add(minusZero, { roundingMode: "floor" }).toString()
+        ).toStrictEqual("-0");
     });
     test("two negatives", () => {
         expect(minusOne.add(new Decimal("-99")).toString()).toStrictEqual(

--- a/tests/Decimal/subtract.test.js
+++ b/tests/Decimal/subtract.test.js
@@ -62,8 +62,14 @@ describe("subtract", () => {
     describe("zero", () => {
         let d = new Decimal("42.65");
         let zero = POSITIVE_ZERO;
+        let minusZero = NEGATIVE_ZERO;
         test("difference is zero", () => {
             expect(d.subtract(d).toString()).toStrictEqual("0");
+        });
+        test("exact cancellation is minus zero when rounding toward negative", () => {
+            expect(
+                d.subtract(d, { roundingMode: "floor" }).toString()
+            ).toStrictEqual("-0");
         });
         test("subtracting zero", () => {
             expect(d.subtract(zero).toString()).toStrictEqual("42.65");
@@ -71,12 +77,43 @@ describe("subtract", () => {
         test("subtracting zero", () => {
             expect(zero.subtract(d).toString()).toStrictEqual("-42.65");
         });
+        test("zero minus zero", () => {
+            expect(zero.subtract(zero).toString()).toStrictEqual("0");
+        });
+        test("minus zero minus minus zero", () => {
+            expect(minusZero.subtract(minusZero).toString()).toStrictEqual("0");
+        });
+        test("like-signed zeros are minus zero when rounding toward negative", () => {
+            expect(
+                zero.subtract(zero, { roundingMode: "floor" }).toString()
+            ).toStrictEqual("-0");
+            expect(
+                minusZero
+                    .subtract(minusZero, { roundingMode: "floor" })
+                    .toString()
+            ).toStrictEqual("-0");
+        });
     });
     describe("minus zero", () => {
         let x = new Decimal("42.54");
+        let zero = POSITIVE_ZERO;
         let minusZero = NEGATIVE_ZERO;
         test("subtracting minus zero", () => {
             expect(x.subtract(minusZero).toString()).toStrictEqual("42.54");
+        });
+        test("zero minus minus zero", () => {
+            expect(zero.subtract(minusZero).toString()).toStrictEqual("0");
+        });
+        test("minus zero minus zero", () => {
+            expect(minusZero.subtract(zero).toString()).toStrictEqual("-0");
+        });
+        test("x minus negated x keeps the sign of x even when rounding toward negative", () => {
+            expect(
+                zero.subtract(minusZero, { roundingMode: "floor" }).toString()
+            ).toStrictEqual("0");
+            expect(
+                minusZero.subtract(zero, { roundingMode: "floor" }).toString()
+            ).toStrictEqual("-0");
         });
     });
 
@@ -252,13 +289,13 @@ describe("subtract", () => {
 
             test("subtraction resulting in underflow", () => {
                 const tiny = new Decimal("1E-6180");
-                // Both underflow to zero, result is -0 because second operand determines sign
-                expect(tiny.subtract(tiny).toString()).toStrictEqual("-0");
+                // Both underflow to zero on construction, and 0 - 0 = 0
+                expect(tiny.subtract(tiny).toString()).toStrictEqual("0");
 
-                // Different tiny values - both underflow to 0, so 0 - 0 = -0
+                // Different tiny values - both underflow to 0, so 0 - 0 = 0
                 const tiny1 = new Decimal("2E-6180");
                 const tiny2 = new Decimal("1E-6180");
-                expect(tiny1.subtract(tiny2).toString()).toStrictEqual("-0");
+                expect(tiny1.subtract(tiny2).toString()).toStrictEqual("0");
             });
         });
 


### PR DESCRIPTION
Fixes #101.

Both `add` and `subtract` now special-case two zero operands up front — the sign-preserving cases (like-signed zeros in `add`; x − (−x) in `subtract`) return a clone — and both exact-cancellation paths share a helper that returns +0, or −0 under `floor`, per IEEE 754-2019 §6.3. `subtract` had the mirror image of the `add` bug (`0 - 0` went through `x.negate()`, and its cancellation path ignored the rounding mode), so it's fixed here too.

One subtlety: tests/Decimal/subtract.test.js asserted that `1E-6180 − 1E-6180` is `-0` "because second operand determines sign" — but those operands underflow to +0 in the constructor, so this is just `0 − 0`. The test now expects `0`.