### PR TITLE
Keep exact zeros at zero in roundToExponent

### DIFF
--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -445,6 +445,13 @@ export class CoefficientExponent {
         targetExponent: number,
         mode: RoundingMode
     ): CoefficientExponent {
+        // Zero is a multiple of every 10^t; without this check it would
+        // fall into the all-digits-below-target path, where ceil rounds
+        // away from zero and would produce 10^t.
+        if (this.isZero()) {
+            return this;
+        }
+
         if (this._exponent >= targetExponent) {
             return this;
         }

--- a/tests/CoefficientExponent/roundToExponent.test.js
+++ b/tests/CoefficientExponent/roundToExponent.test.js
@@ -1,0 +1,24 @@
+import { CoefficientExponent } from "../../src/CoefficientExponent.mjs";
+
+const ROUNDING_MODES = ["ceil", "floor", "trunc", "halfEven", "halfExpand"];
+
+describe("roundToExponent", () => {
+    describe("zero at a positive target exponent", () => {
+        ROUNDING_MODES.forEach((mode) => {
+            test(`zero stays zero under ${mode}`, () => {
+                expect(
+                    CoefficientExponent.from("0")
+                        .roundToExponent(2, mode)
+                        .toString()
+                ).toStrictEqual("0");
+            });
+        });
+        test("negative zero stays zero under ceil", () => {
+            expect(
+                CoefficientExponent.from("-0")
+                    .roundToExponent(2, "ceil")
+                    .toString()
+            ).toStrictEqual("-0");
+        });
+    });
+});

--- a/tests/CoefficientExponent/roundToExponent.test.js
+++ b/tests/CoefficientExponent/roundToExponent.test.js
@@ -1,6 +1,5 @@
 import { CoefficientExponent } from "../../src/CoefficientExponent.mjs";
-
-const ROUNDING_MODES = ["ceil", "floor", "trunc", "halfEven", "halfExpand"];
+import { ROUNDING_MODE_CEILING, ROUNDING_MODES } from "../../src/Rounding.mjs";
 
 describe("roundToExponent", () => {
     describe("zero at a positive target exponent", () => {
@@ -16,7 +15,7 @@ describe("roundToExponent", () => {
         test("negative zero stays zero under ceil", () => {
             expect(
                 CoefficientExponent.from("-0")
-                    .roundToExponent(2, "ceil")
+                    .roundToExponent(2, ROUNDING_MODE_CEILING)
                     .toString()
             ).toStrictEqual("-0");
         });


### PR DESCRIPTION
Return zero unchanged before the exponent checks: it is already a multiple of every power of ten, so no rounding mode should move it. Adds direct unit tests for `CoefficientExponent` since the buggy path is not reachable from the public API.

Fixes #110