### PR TITLE
Use a consistent options-bag signature for round, toFixed, toPrecision, and toExponential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses date-based versioning (YYYYMMDD.MAJOR.MINOR).
 
+## [20260710.0.0] - 2026-07-10
+
+### Changed
+
+- `round` takes an options bag (`{ digits, roundingMode }`) instead of
+  positional arguments (#40)
+- `toFixed`, `toPrecision`, and `toExponential` accept the same options
+  bag; `toFixed` defaults `digits` to 0, following
+  `Number.prototype.toFixed`, and `toExponential` accepts `digits: 0`
+- `toFixed` no longer accepts `digits: Infinity`
+- Options bags are validated strictly everywhere they are accepted
+  (constructor, arithmetic, rounding, formatting): TypeError for a
+  non-object bag or wrongly-typed option, RangeError for invalid values,
+  even when the receiver is NaN or infinite; unknown keys are ignored
+- At most 10000 digits may be requested via the `digits` option
+
+### Fixed
+
+- Sums and differences that cancel exactly follow the IEEE 754 rule for
+  the sign of a zero result (#115)
+- Rounding an exact zero keeps it at zero under directed rounding modes
+  (#116)
+- `toExponential` with `digits` requested no longer crashes on
+  single-digit mantissas, and rounds excess digits instead of truncating
+  them (#114)
+- `scale10` results are rounded to the Decimal128 domain (#113)
+- `toBigInt` converts from the internal representation rather than
+  parsing `toString()` output (#112)
+- `remainder` is computed exactly instead of via a rounded quotient
+  (#104)
+- Results in the subnormal range are quantized at Etiny (gradual
+  underflow) (#107)
+
 ## [20260708.0.0] - 2026-07-08
 
 ### Changed

--- a/examples/currency.ts
+++ b/examples/currency.ts
@@ -5,4 +5,4 @@ let amountInUsd = new Decimal("450.27");
 let exchangeRateUsdToEur = new Decimal(1).divide(exchangeRateEurToUsd);
 
 let amountInEur = exchangeRateUsdToEur.multiply(amountInUsd);
-console.log(amountInEur.round(2).toString());
+console.log(amountInEur.round({ digits: 2 }).toString());

--- a/examples/floor.mts
+++ b/examples/floor.mts
@@ -1,7 +1,7 @@
 import { Decimal } from "../src/Decimal.mjs";
 
 function floor(d: Decimal): Decimal {
-    return d.round(0, "floor");
+    return d.round({ roundingMode: "floor" });
 }
 
 export { floor };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "proposal-decimal",
-    "version": "20260708.0.0",
+    "version": "20260710.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "proposal-decimal",
-            "version": "20260708.0.0",
+            "version": "20260710.0.0",
             "license": "BSD-2-Clause",
             "devDependencies": {
                 "@jessealama/pabst": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "proposal-decimal",
-    "version": "20260708.0.0",
+    "version": "20260710.0.0",
     "description": "Champion-maintained polyfill for the TC39 decimal proposal",
     "main": "dist/Decimal.mjs",
     "types": "./src/Decimal.d.mts",

--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -377,6 +377,12 @@ export class CoefficientExponent {
         return this._coefficient % divisor === 0n;
     }
 
+    // Directed modes act on the value, but the digit-level rounding here
+    // works on the magnitude, so flip them for negative values.
+    #modeForMagnitude(mode: RoundingMode): RoundingMode {
+        return this._isNegative ? flipModeForNegative(mode) : mode;
+    }
+
     /**
      * Rounds to a specified number of significant digits.
      * @param {number} numSignificantDigits - The number of significant digits to keep
@@ -415,7 +421,7 @@ export class CoefficientExponent {
             );
 
             const roundUp = shouldRoundAwayFromZero(
-                mode,
+                this.#modeForMagnitude(mode),
                 () => fraction.cmp(halfUnit),
                 () => quotient % 2n === 0n
             );
@@ -434,9 +440,7 @@ export class CoefficientExponent {
 
     /**
      * Rounds to the given exponent (quantum): the result is an integer
-     * multiple of 10^targetExponent. Like roundToSignificantDigits, the
-     * rounding mode is applied to the magnitude; callers handle sign by
-     * flipping the mode for negative values.
+     * multiple of 10^targetExponent.
      * @param {number} targetExponent - The exponent to round at
      * @param {RoundingMode} mode - The rounding mode to use
      * @returns {CoefficientExponent} The rounded value
@@ -474,7 +478,7 @@ export class CoefficientExponent {
         // comparing against half a unit compares two coefficients of the
         // same length.
         const roundUp = shouldRoundAwayFromZero(
-            mode,
+            this.#modeForMagnitude(mode),
             () => {
                 if (digitsToRemove > currentDigits) {
                     return -1;
@@ -505,13 +509,7 @@ export class CoefficientExponent {
         numFractionalDigits: number,
         mode: RoundingMode
     ): CoefficientExponent {
-        // Keeping numFractionalDigits fractional digits is rounding at
-        // exponent -numFractionalDigits; roundToExponent applies the mode
-        // to the magnitude, so flip it here for negative values.
-        const adjustedMode = this._isNegative
-            ? flipModeForNegative(mode)
-            : mode;
-        return this.roundToExponent(-numFractionalDigits, adjustedMode);
+        return this.roundToExponent(-numFractionalDigits, mode);
     }
 
     /**
@@ -522,12 +520,7 @@ export class CoefficientExponent {
      * @throws {RangeError} If digits is not positive or not an integer
      */
     toPrecision(digits: number, mode: RoundingMode): string {
-        // roundToSignificantDigits applies the mode to the magnitude, so
-        // flip directed modes for negative values (as round does above).
-        const adjustedMode = this._isNegative
-            ? flipModeForNegative(mode)
-            : mode;
-        const rounded = this.roundToSignificantDigits(digits, adjustedMode);
+        const rounded = this.roundToSignificantDigits(digits, mode);
 
         // Calculate the effective exponent (where decimal point would be after the first digit)
         const coeffStr = rounded._coefficient.toString();

--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -517,14 +517,17 @@ export class CoefficientExponent {
     /**
      * Formats with a specified number of significant digits.
      * @param {number} digits - The number of significant digits
+     * @param {RoundingMode} mode - The rounding mode to use
      * @returns {string} The formatted string in decimal or exponential notation
      * @throws {RangeError} If digits is not positive or not an integer
      */
-    toPrecision(digits: number): string {
-        const rounded = this.roundToSignificantDigits(
-            digits,
-            ROUNDING_MODE_HALF_EVEN
-        );
+    toPrecision(digits: number, mode: RoundingMode): string {
+        // roundToSignificantDigits applies the mode to the magnitude, so
+        // flip directed modes for negative values (as round does above).
+        const adjustedMode = this._isNegative
+            ? flipModeForNegative(mode)
+            : mode;
+        const rounded = this.roundToSignificantDigits(digits, adjustedMode);
 
         // Calculate the effective exponent (where decimal point would be after the first digit)
         const coeffStr = rounded._coefficient.toString();

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -46,7 +46,9 @@ const NEGATIVE_INFINITY = "-Infinity";
 
 type OptionsBag = { digits?: unknown; roundingMode?: unknown };
 
-const MAX_REQUESTED_DIGITS = 1_000_000_000;
+// Comfortably above the ~6200 digits a Decimal128 value can occupy (34
+// significant digits, quantum exponents down to Etiny = -6176).
+const MAX_REQUESTED_DIGITS = 10_000;
 
 function ensureOptionsBag(opts: unknown): OptionsBag | undefined {
     if (undefined === opts) {

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -632,8 +632,8 @@ export class Decimal {
             return p + "0." + "0".repeat(n) + "e+0";
         }
 
-        // Round the signed mantissa so that directed modes (ceil, floor)
-        // act on the value, not its magnitude; render the absolute value.
+        // Round before taking the absolute value so that directed modes
+        // (ceil, floor) see the sign.
         let rounded = this.mantissa().round({ digits: n, roundingMode }).abs();
         let e = this.exponent();
 

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -44,6 +44,64 @@ const NAN = "NaN";
 const POSITIVE_INFINITY = "Infinity";
 const NEGATIVE_INFINITY = "-Infinity";
 
+type OptionsBag = { digits?: unknown; roundingMode?: unknown };
+
+const MAX_REQUESTED_DIGITS = 1_000_000_000;
+
+function ensureOptionsBag(opts: unknown): OptionsBag | undefined {
+    if (undefined === opts) {
+        return undefined;
+    }
+
+    if (null === opts || "object" !== typeof opts) {
+        throw new TypeError("Argument must be an object");
+    }
+
+    return opts as OptionsBag;
+}
+
+function readDigits(bag: OptionsBag | undefined): number | undefined {
+    if (undefined === bag || undefined === bag.digits) {
+        return undefined;
+    }
+
+    let digits = bag.digits;
+
+    if ("number" !== typeof digits) {
+        throw new TypeError("digits must be a number");
+    }
+
+    if (!Number.isInteger(digits)) {
+        throw new RangeError("digits must be an integer");
+    }
+
+    if (digits < 0) {
+        throw new RangeError("digits must be non-negative");
+    }
+
+    if (digits > MAX_REQUESTED_DIGITS) {
+        throw new RangeError("Too many digits requested");
+    }
+
+    return digits;
+}
+
+function readRoundingMode(bag: OptionsBag | undefined): RoundingMode {
+    if (undefined === bag || undefined === bag.roundingMode) {
+        return ROUNDING_MODE_HALF_EVEN;
+    }
+
+    if ("string" !== typeof bag.roundingMode) {
+        throw new TypeError("roundingMode must be a string");
+    }
+
+    if (!ROUNDING_MODES.includes(bag.roundingMode as RoundingMode)) {
+        throw new RangeError(`Invalid rounding mode "${bag.roundingMode}"`);
+    }
+
+    return bag.roundingMode as RoundingMode;
+}
+
 function RoundToDecimal128Domain(
     v: CoefficientExponent,
     mode: RoundingMode = ROUNDING_MODE_HALF_EVEN
@@ -480,7 +538,7 @@ export class Decimal {
             );
         }
 
-        let rounded = this.round(n);
+        let rounded = this.round({ digits: n });
         let roundedRendered = rounded.#emitDecimal();
 
         if (roundedRendered.match(/[.]/)) {
@@ -608,7 +666,7 @@ export class Decimal {
         let m = this.abs().mantissa();
         let e = this.exponent();
 
-        let rounded = m.round(n);
+        let rounded = m.round({ digits: n });
 
         if (rounded.exponent() === 1) {
             // Rounding carried the mantissa out of [1, 10).
@@ -1210,36 +1268,27 @@ export class Decimal {
     }
 
     /**
-     * Rounds this Decimal128 value to a specified number of decimal places.
+     * Rounds this Decimal128 value to a specified number of fractional digits.
      *
-     * @param {number} [numDecimalDigits=0] The number of decimal places to round to.
-     *   Must be a non-negative integer.
-     * @param {RoundingMode} [mode="halfEven"] The rounding mode to use.
+     * @param {Object} [opts] Optional configuration object
+     * @param {number} [opts.digits] The number of fractional digits to round to.
+     *   Must be a non-negative integer. Defaults to 0 (round to an integer).
+     * @param {RoundingMode} [opts.roundingMode] The rounding mode to use.
      *   Valid values are: "ceil", "floor", "trunc", "halfEven", "halfExpand".
-     * @returns {Decimal} A new Decimal value rounded to the specified number of decimal places
-     * @throws {RangeError} If the rounding mode is invalid
-     * @throws {RangeError} If numDecimalDigits is negative or not an integer
+     *   Defaults to "halfEven".
+     * @returns {Decimal} A new Decimal value rounded to the specified number of fractional digits
+     * @throws {TypeError} If opts is not an object, digits is not a number, or roundingMode is not a string
+     * @throws {RangeError} If digits is negative, not an integer, or too large, or roundingMode is not a valid rounding mode
      *
      * @ensures{idempotent} forall (x: number) (n: nat),
      *   Number.isFinite(x) →
-     *     new Decimal(x).round(n % 50).round(n % 50).toString() ===
-     *       new Decimal(x).round(n % 50).toString()
+     *     new Decimal(x).round({ digits: n % 50 }).round({ digits: n % 50 }).toString() ===
+     *       new Decimal(x).round({ digits: n % 50 }).toString()
      */
-    round(
-        numDecimalDigits: number = 0,
-        mode: RoundingMode = ROUNDING_MODE_HALF_EVEN
-    ): Decimal {
-        if (!ROUNDING_MODES.includes(mode)) {
-            throw new RangeError(`Invalid rounding mode "${mode}"`);
-        }
-
-        if (!Number.isInteger(numDecimalDigits) || numDecimalDigits < 0) {
-            throw new RangeError("Invalid number of decimal digits");
-        }
-
-        if (numDecimalDigits > 1e9) {
-            throw new RangeError("Too many decimal digits requested");
-        }
+    round(opts?: { digits?: number; roundingMode?: RoundingMode }): Decimal {
+        const bag = ensureOptionsBag(opts);
+        const mode = readRoundingMode(bag);
+        const numFractionalDigits = readDigits(bag) ?? 0;
 
         if (this.isNaN() || !this.isFinite()) {
             return this.#clone();
@@ -1250,7 +1299,7 @@ export class Decimal {
         }
 
         let v = this.#d as CoefficientExponent;
-        let roundedV = v.round(numDecimalDigits, mode);
+        let roundedV = v.round(numFractionalDigits, mode);
 
         if (roundedV.isZero()) {
             return new Decimal(v.isNegative ? "-0" : "0");

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -232,6 +232,8 @@ export class Decimal {
      * @param opts.roundingMode Specifies the rounding mode to use if rounding is needed during construction.
      *   Valid values are: "ceil", "floor", "trunc", "halfEven", "halfExpand".
      *   Defaults to "halfEven".
+     * @throws {TypeError} If opts is not an object or roundingMode is not a string
+     * @throws {RangeError} If roundingMode is not a valid rounding mode
      * @throws {SyntaxError} If the string format is invalid
      * @throws {RangeError} If the value cannot be represented as a Decimal128
      *
@@ -263,16 +265,9 @@ export class Decimal {
                 s = n;
             }
 
-            let mode = ROUNDING_MODE_HALF_EVEN;
-            if (
-                undefined !== opts &&
-                "object" === typeof opts &&
-                opts.roundingMode !== undefined
-            ) {
-                mode = opts.roundingMode;
-            }
+            const mode = readRoundingMode(ensureOptionsBag(opts));
 
-            data = handleDecimalNotation(s, mode as RoundingMode);
+            data = handleDecimalNotation(s, mode);
         }
 
         if (data === "NaN") {
@@ -906,6 +901,8 @@ export class Decimal {
      *   enumeration, such as `ROUNDING_MODE_HALF_EVEN`, `ROUNDING_MODE_TRUNCATE`,
      *   `ROUNDING_MODE_CEILING`, and `ROUNDING_MODE_FLOOR`. Defaults to
      *   `ROUNDING_MODE_HALF_EVEN`.
+     * @throws {TypeError} If opts is not an object or roundingMode is not a string
+     * @throws {RangeError} If roundingMode is not a valid rounding mode
      *
      * @ensures{commutes} forall (x y: number),
      *   new Decimal(x).add(new Decimal(y)).toString() ===
@@ -916,15 +913,7 @@ export class Decimal {
      *     new Decimal(x).add(new Decimal(x).negate()).toString() === "0"
      */
     add(x: Decimal, opts?: { roundingMode?: RoundingMode }): Decimal {
-        let mode: RoundingMode = ROUNDING_MODE_HALF_EVEN;
-
-        if (
-            undefined !== opts &&
-            "object" === typeof opts &&
-            opts.roundingMode !== undefined
-        ) {
-            mode = opts.roundingMode;
-        }
+        const mode = readRoundingMode(ensureOptionsBag(opts));
 
         if (this.isNaN() || x.isNaN()) {
             return new Decimal(NAN);
@@ -986,21 +975,15 @@ export class Decimal {
      *   when performing the subtraction. Valid values are: "ceil", "floor", "trunc",
      *   "halfEven", "halfExpand". Defaults to "halfEven".
      * @returns {Decimal} A new Decimal value representing the difference
+     * @throws {TypeError} If opts is not an object or roundingMode is not a string
+     * @throws {RangeError} If roundingMode is not a valid rounding mode
      *
      * @ensures{antiCommutes} forall (x y: number),
      *   Number.isFinite(x) ∧ Number.isFinite(y) →
      *     new Decimal(x).subtract(new Decimal(y)).equals(new Decimal(y).subtract(new Decimal(x)).negate())
      */
     subtract(x: Decimal, opts?: { roundingMode?: RoundingMode }): Decimal {
-        let mode: RoundingMode = ROUNDING_MODE_HALF_EVEN;
-
-        if (
-            undefined !== opts &&
-            "object" === typeof opts &&
-            opts.roundingMode !== undefined
-        ) {
-            mode = opts.roundingMode;
-        }
+        const mode = readRoundingMode(ensureOptionsBag(opts));
 
         if (this.isNaN() || x.isNaN()) {
             return new Decimal(NAN);
@@ -1065,6 +1048,8 @@ export class Decimal {
      *   when performing the multiplication. Valid values are: "ceil", "floor", "trunc",
      *   "halfEven", "halfExpand". Defaults to "halfEven".
      * @returns {Decimal} A new Decimal value representing the product
+     * @throws {TypeError} If opts is not an object or roundingMode is not a string
+     * @throws {RangeError} If roundingMode is not a valid rounding mode
      *
      * @ensures{commutes} forall (x y: number),
      *   new Decimal(x).multiply(new Decimal(y)).toString() ===
@@ -1076,15 +1061,7 @@ export class Decimal {
      *       (new Decimal(j + "e-3090").multiply(new Decimal(k + "e-3090")).significand().toString().length - 1) >= -6176
      */
     multiply(x: Decimal, opts?: { roundingMode?: RoundingMode }): Decimal {
-        let mode: RoundingMode = ROUNDING_MODE_HALF_EVEN;
-
-        if (
-            undefined !== opts &&
-            "object" === typeof opts &&
-            opts.roundingMode !== undefined
-        ) {
-            mode = opts.roundingMode;
-        }
+        const mode = readRoundingMode(ensureOptionsBag(opts));
 
         if (this.isNaN() || x.isNaN()) {
             return new Decimal(NAN);
@@ -1161,6 +1138,8 @@ export class Decimal {
      *   when performing the division. Valid values are: "ceil", "floor", "trunc",
      *   "halfEven", "halfExpand". Defaults to "halfEven".
      * @returns {Decimal} A new Decimal value representing the quotient
+     * @throws {TypeError} If opts is not an object or roundingMode is not a string
+     * @throws {RangeError} If roundingMode is not a valid rounding mode
      *
      * @ensures{selfDivisionIsUnity} forall (x: number),
      *   Number.isFinite(x) ∧ x !== 0 →
@@ -1172,15 +1151,7 @@ export class Decimal {
      *       (new Decimal(k + "e-6170").divide(new Decimal("1e" + n)).significand().toString().length - 1) >= -6176
      */
     divide(x: Decimal, opts?: { roundingMode?: RoundingMode }): Decimal {
-        let mode: RoundingMode = ROUNDING_MODE_HALF_EVEN;
-
-        if (
-            undefined !== opts &&
-            "object" === typeof opts &&
-            opts.roundingMode !== undefined
-        ) {
-            mode = opts.roundingMode;
-        }
+        const mode = readRoundingMode(ensureOptionsBag(opts));
 
         if (this.isNaN() || x.isNaN()) {
             return new Decimal(NAN);

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -62,7 +62,10 @@ function ensureOptionsBag(opts: unknown): OptionsBag | undefined {
     return opts as OptionsBag;
 }
 
-function readDigits(bag: OptionsBag | undefined): number | undefined {
+function readDigits(
+    bag: OptionsBag | undefined,
+    minimum: 0 | 1 = 0
+): number | undefined {
     if (undefined === bag || undefined === bag.digits) {
         return undefined;
     }
@@ -77,8 +80,12 @@ function readDigits(bag: OptionsBag | undefined): number | undefined {
         throw new RangeError("digits must be an integer");
     }
 
-    if (digits < 0) {
-        throw new RangeError("digits must be non-negative");
+    if (digits < minimum) {
+        throw new RangeError(
+            0 === minimum
+                ? "digits must be non-negative"
+                : "digits must be positive"
+        );
     }
 
     if (digits > MAX_REQUESTED_DIGITS) {
@@ -549,14 +556,10 @@ export class Decimal {
     }): string {
         const bag = ensureOptionsBag(opts);
         const roundingMode = readRoundingMode(bag);
-        const precision = readDigits(bag);
+        const precision = readDigits(bag, 1);
 
         if (undefined === precision) {
             return this.toString();
-        }
-
-        if (0 === precision) {
-            throw new RangeError("digits must be positive");
         }
 
         if (this.isNaN()) {

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -253,6 +253,8 @@ export class Decimal {
         let data;
         let s: string;
 
+        const mode = readRoundingMode(ensureOptionsBag(opts));
+
         // Handle CoefficientExponent directly to avoid toString() with large exponents
         if (n instanceof CoefficientExponent) {
             data = n;
@@ -264,8 +266,6 @@ export class Decimal {
             } else {
                 s = n;
             }
-
-            const mode = readRoundingMode(ensureOptionsBag(opts));
 
             data = handleDecimalNotation(s, mode);
         }

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -440,7 +440,7 @@ export class Decimal {
 
         let m = this.mantissa();
 
-        let mAsString = m.toFixed({ digits: Infinity });
+        let mAsString = m.#emitDecimal();
         return mAsString + formatExponent(e);
     }
 
@@ -486,37 +486,25 @@ export class Decimal {
 
     /**
      * Returns a string representation of this Decimal128 value in fixed-point notation.
+     * The result always uses plain decimal notation, never exponential.
      *
      * @param {Object} [opts] Optional configuration object
      * @param {number} [opts.digits] The number of digits to appear after the decimal point.
-     *   Must be an integer >= 0. If not specified, uses the default toString() behavior.
-     *   If Infinity, returns the full decimal representation without exponential notation.
+     *   Must be a non-negative integer. Defaults to 0.
+     * @param {RoundingMode} [opts.roundingMode] The rounding mode to use if the value
+     *   has more fractional digits than requested. Defaults to "halfEven".
      * @returns {string} The string representation in fixed-point notation
-     * @throws {TypeError} If opts is not an object
-     * @throws {RangeError} If digits is negative, NaN, or not an integer (except Infinity)
+     * @throws {TypeError} If opts is not an object, digits is not a number, or roundingMode is not a string
+     * @throws {RangeError} If digits is negative, not an integer (including NaN and Infinity), or too large, or roundingMode is invalid
      *
      * @ensures{padsToRequestedDigits} forall (x: number) (n: nat),
      *   Number.isFinite(x) →
      *     (new Decimal(x).toFixed({ digits: 1 + (n % 80) }).split(".")[1] ?? "").length === 1 + (n % 80)
      */
-    toFixed(opts?: { digits?: number }): string {
-        if (undefined === opts) {
-            return this.toString();
-        }
-
-        if ("object" !== typeof opts) {
-            throw new TypeError("Argument must be an object");
-        }
-
-        if (undefined === opts.digits) {
-            return this.toString();
-        }
-
-        let n = opts.digits;
-
-        if (n < 0) {
-            throw new RangeError("Argument must be greater than or equal to 0");
-        }
+    toFixed(opts?: { digits?: number; roundingMode?: RoundingMode }): string {
+        const bag = ensureOptionsBag(opts);
+        const roundingMode = readRoundingMode(bag);
+        const n = readDigits(bag) ?? 0;
 
         if (this.isNaN()) {
             return NAN;
@@ -528,17 +516,7 @@ export class Decimal {
                 : POSITIVE_INFINITY;
         }
 
-        if (n === Infinity) {
-            return this.#emitDecimal();
-        }
-
-        if (!Number.isInteger(n)) {
-            throw new RangeError(
-                "Argument must be an integer or positive infinity"
-            );
-        }
-
-        let rounded = this.round({ digits: n });
+        let rounded = this.round({ digits: n, roundingMode });
         let roundedRendered = rounded.#emitDecimal();
 
         if (roundedRendered.match(/[.]/)) {

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -520,22 +520,20 @@ export class Decimal {
                 : POSITIVE_INFINITY;
         }
 
-        let rounded = this.round({ digits: n, roundingMode });
-        let roundedRendered = rounded.#emitDecimal();
+        return this.#round(n, roundingMode).#emitFixed(n);
+    }
 
-        if (roundedRendered.match(/[.]/)) {
-            let [lhs, rhs] = roundedRendered.split(/[.]/);
-            let numFractionDigits = rhs.length;
-            if (numFractionDigits <= n) {
-                return lhs + "." + rhs + "0".repeat(n - numFractionDigits);
-            }
+    // Fixed-point rendering with exactly n fractional digits; assumes the
+    // value has at most n of them.
+    #emitFixed(n: number): string {
+        const rendered = this.#emitDecimal();
+        const [lhs, rhs] = rendered.split(".");
+
+        if (undefined === rhs) {
+            return 0 === n ? rendered : rendered + "." + "0".repeat(n);
         }
 
-        if (n === 0) {
-            return roundedRendered;
-        }
-
-        return roundedRendered + "." + "0".repeat(n);
+        return lhs + "." + rhs + "0".repeat(n - rhs.length);
     }
 
     /**
@@ -634,7 +632,7 @@ export class Decimal {
 
         // Round before taking the absolute value so that directed modes
         // (ceil, floor) see the sign.
-        let rounded = this.mantissa().round({ digits: n, roundingMode }).abs();
+        let rounded = this.mantissa().#round(n, roundingMode).abs();
         let e = this.exponent();
 
         if (rounded.exponent() === 1) {
@@ -643,7 +641,7 @@ export class Decimal {
             e += 1;
         }
 
-        return p + rounded.toFixed({ digits: n }) + formatExponent(e);
+        return p + rounded.#emitFixed(n) + formatExponent(e);
     }
 
     #isInteger(): boolean {
@@ -1235,6 +1233,10 @@ export class Decimal {
         const mode = readRoundingMode(bag);
         const numFractionalDigits = readDigits(bag) ?? 0;
 
+        return this.#round(numFractionalDigits, mode);
+    }
+
+    #round(numFractionalDigits: number, mode: RoundingMode): Decimal {
         if (this.isNaN() || !this.isFinite()) {
             return this.#clone();
         }

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -539,31 +539,27 @@ export class Decimal {
      *
      * @param {Object} [opts] Optional configuration object
      * @param {number} [opts.digits] The number of significant digits. Must be a positive integer.
+     *   If omitted, behaves like toString().
+     * @param {RoundingMode} [opts.roundingMode] The rounding mode to use if the value
+     *   has more significant digits than requested. Defaults to "halfEven".
      * @returns {string} The string representation with the specified precision
-     * @throws {TypeError} If opts is not an object
-     * @throws {RangeError} If digits is not a positive integer
+     * @throws {TypeError} If opts is not an object, digits is not a number, or roundingMode is not a string
+     * @throws {RangeError} If digits is not a positive integer, or roundingMode is invalid
      */
-    toPrecision(opts?: { digits?: number }): string {
-        if (undefined === opts) {
+    toPrecision(opts?: {
+        digits?: number;
+        roundingMode?: RoundingMode;
+    }): string {
+        const bag = ensureOptionsBag(opts);
+        const roundingMode = readRoundingMode(bag);
+        const precision = readDigits(bag);
+
+        if (undefined === precision) {
             return this.toString();
         }
 
-        if ("object" !== typeof opts) {
-            throw new TypeError("Argument must be an object");
-        }
-
-        if (undefined === opts.digits) {
-            return this.toString();
-        }
-
-        let precision = opts.digits;
-
-        if (precision <= 0) {
-            throw new RangeError("Argument must be positive");
-        }
-
-        if (!Number.isInteger(precision)) {
-            throw new RangeError("Argument must be an integer");
+        if (0 === precision) {
+            throw new RangeError("digits must be positive");
         }
 
         if (this.isNaN()) {
@@ -587,7 +583,7 @@ export class Decimal {
         }
 
         let d = this.#d as CoefficientExponent;
-        return d.toPrecision(precision);
+        return d.toPrecision(precision, roundingMode);
     }
 
     /**

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -591,16 +591,25 @@ export class Decimal {
      *
      * @param {Object} [opts] Optional configuration object
      * @param {number} [opts.digits] The number of digits after the decimal point in the mantissa.
-     *   Must be a positive integer.
+     *   Must be a non-negative integer. If omitted, uses as many digits as needed.
+     * @param {RoundingMode} [opts.roundingMode] The rounding mode to use if the mantissa
+     *   has more fractional digits than requested. Defaults to "halfEven".
      * @returns {string} The string representation in exponential notation
-     * @throws {TypeError} If opts is not an object
-     * @throws {RangeError} If digits is not a positive integer
+     * @throws {TypeError} If opts is not an object, digits is not a number, or roundingMode is not a string
+     * @throws {RangeError} If digits is negative, not an integer, or too large, or roundingMode is invalid
      *
      * @ensures{honorsRequestedDigits} forall (x: number) (n: nat),
      *   Number.isFinite(x) →
      *     new Decimal(x).toExponential({ digits: 1 + (n % 30) }).split("e")[0].split(".")[1].length === 1 + (n % 30)
      */
-    toExponential(opts?: { digits?: number }): string {
+    toExponential(opts?: {
+        digits?: number;
+        roundingMode?: RoundingMode;
+    }): string {
+        const bag = ensureOptionsBag(opts);
+        const roundingMode = readRoundingMode(bag);
+        const n = readDigits(bag);
+
         if (this.isNaN()) {
             return "NaN";
         }
@@ -609,38 +618,24 @@ export class Decimal {
             return (this.isNegative() ? "-" : "") + "Infinity";
         }
 
-        if (undefined === opts) {
+        if (undefined === n) {
             return this.#emitExponential();
-        }
-
-        if ("object" !== typeof opts) {
-            throw new TypeError("Argument must be an object");
-        }
-
-        if (undefined === opts.digits) {
-            return this.#emitExponential();
-        }
-
-        let n = opts.digits;
-
-        if (n <= 0) {
-            throw new RangeError("Argument must be positive");
-        }
-
-        if (!Number.isInteger(n)) {
-            throw new RangeError("Argument must be an integer");
         }
 
         let p = this.isNegative() ? "-" : "";
 
         if (this.isZero()) {
+            if (n === 0) {
+                return p + "0e+0";
+            }
+
             return p + "0." + "0".repeat(n) + "e+0";
         }
 
-        let m = this.abs().mantissa();
+        // Round the signed mantissa so that directed modes (ceil, floor)
+        // act on the value, not its magnitude; render the absolute value.
+        let rounded = this.mantissa().round({ digits: n, roundingMode }).abs();
         let e = this.exponent();
-
-        let rounded = m.round({ digits: n });
 
         if (rounded.exponent() === 1) {
             // Rounding carried the mantissa out of [1, 10).

--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -6,6 +6,7 @@ import {
     POSITIVE_ZERO,
     NEGATIVE_ZERO,
 } from "./special-values.js";
+import { describeOptionsBagValidation } from "./util.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
@@ -308,19 +309,4 @@ describe("addition", () => {
     });
 });
 
-describe("options bag validation", () => {
-    let a = new Decimal("1");
-    let b = new Decimal("2");
-    test("non-object options throws TypeError", () => {
-        expect(() => a.add(b, "ceil")).toThrow(TypeError);
-    });
-    test("non-string roundingMode throws TypeError", () => {
-        expect(() => a.add(b, { roundingMode: 42 })).toThrow(TypeError);
-    });
-    test("invalid roundingMode string throws RangeError", () => {
-        expect(() => a.add(b, { roundingMode: "bogus" })).toThrow(RangeError);
-    });
-    test("unknown keys are ignored", () => {
-        expect(a.add(b, { digits: 1 }).toString()).toStrictEqual("3");
-    });
-});
+describeOptionsBagValidation("add", "3");

--- a/tests/Decimal/add.test.js
+++ b/tests/Decimal/add.test.js
@@ -307,3 +307,20 @@ describe("addition", () => {
         });
     });
 });
+
+describe("options bag validation", () => {
+    let a = new Decimal("1");
+    let b = new Decimal("2");
+    test("non-object options throws TypeError", () => {
+        expect(() => a.add(b, "ceil")).toThrow(TypeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => a.add(b, { roundingMode: 42 })).toThrow(TypeError);
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => a.add(b, { roundingMode: "bogus" })).toThrow(RangeError);
+    });
+    test("unknown keys are ignored", () => {
+        expect(a.add(b, { digits: 1 }).toString()).toStrictEqual("3");
+    });
+});

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -444,3 +444,19 @@ describe("constructor", () => {
         });
     });
 });
+
+describe("options bag validation", () => {
+    test("non-object options throws TypeError", () => {
+        expect(() => new Decimal("1.5", "ceil")).toThrow(TypeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => new Decimal("1.5", { roundingMode: 42 })).toThrow(
+            TypeError
+        );
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => new Decimal("1.5", { roundingMode: "bogus" })).toThrow(
+            RangeError
+        );
+    });
+});

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -9,37 +9,37 @@ describe("constructor", () => {
         });
         test("string with underscores (comprehensive)", () => {
             // Test various underscore patterns in one test
-            expect(
-                new Decimal("123_456.789").toFixed({ digits: Infinity })
-            ).toStrictEqual("123456.789");
-            expect(
-                new Decimal("123_456_789.123").toFixed({ digits: Infinity })
-            ).toStrictEqual("123456789.123");
-            expect(
-                new Decimal("123.456_789").toFixed({ digits: Infinity })
-            ).toStrictEqual("123.456789");
-            expect(
-                new Decimal("123_456.789_123").toFixed({ digits: Infinity })
-            ).toStrictEqual("123456.789123");
+            expect(new Decimal("123_456.789").toString()).toStrictEqual(
+                "123456.789"
+            );
+            expect(new Decimal("123_456_789.123").toString()).toStrictEqual(
+                "123456789.123"
+            );
+            expect(new Decimal("123.456_789").toString()).toStrictEqual(
+                "123.456789"
+            );
+            expect(new Decimal("123_456.789_123").toString()).toStrictEqual(
+                "123456.789123"
+            );
         });
         test("more significant digits than we can store", () => {
             expect(
                 new Decimal("123456789123456789123456789123456789").toFixed({
-                    digits: Infinity,
+                    digits: 0,
                 })
             ).toStrictEqual("123456789123456789123456789123456800");
         });
         test("five as last digit past limit: tie to even unchanged", () => {
             expect(
                 new Decimal("1234567890123456789012345678901234.5").toFixed({
-                    digits: Infinity,
+                    digits: 0,
                 })
             ).toStrictEqual("1234567890123456789012345678901234");
         });
         test("round up decimal digit is not nine", () => {
             expect(
                 new Decimal("1234567890123456789012345678901239.8").toFixed({
-                    digits: Infinity,
+                    digits: 0,
                 })
             ).toStrictEqual("1234567890123456789012345678901240");
         });
@@ -52,15 +52,13 @@ describe("constructor", () => {
         });
         test("large power of ten", () => {
             let s = "10000000000000000000000000000000000000000000";
-            expect(new Decimal(s).toFixed({ digits: Infinity })).toStrictEqual(
-                s
-            );
+            expect(new Decimal(s).toFixed({ digits: 0 })).toStrictEqual(s);
         });
         test("rounding at the limit of significant digits", () => {
             expect(
                 new Decimal(
                     "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS) + "9"
-                ).toFixed({ digits: Infinity })
+                ).toString()
             ).toStrictEqual(
                 "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS - 1) + "2"
             );
@@ -69,7 +67,7 @@ describe("constructor", () => {
             expect(
                 new Decimal(
                     "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS + 100) + "9"
-                ).toFixed({ digits: Infinity })
+                ).toString()
             ).toStrictEqual("0." + "1".repeat(MAX_SIGNIFICANT_DIGITS));
         });
         test("minus zero", () => {
@@ -101,7 +99,7 @@ describe("constructor", () => {
         test("too many significant digits get rounded", () => {
             expect(
                 new Decimal("-10000000000000000000000000000000008E5").toFixed({
-                    digits: Infinity,
+                    digits: 0,
                 })
             ).toStrictEqual("-1000000000000000000000000000000001000000");
         });
@@ -405,9 +403,7 @@ describe("constructor", () => {
         test("ceil", () => {
             let s = "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS) + "3";
             expect(
-                new Decimal(s, { roundingMode: "ceil" }).toFixed({
-                    digits: Infinity,
-                })
+                new Decimal(s, { roundingMode: "ceil" }).toString()
             ).toStrictEqual(
                 "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS - 1) + "2"
             );
@@ -415,9 +411,7 @@ describe("constructor", () => {
         test("floor", () => {
             let s = "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS) + "9";
             expect(
-                new Decimal(s, { roundingMode: "floor" }).toFixed({
-                    digits: Infinity,
-                })
+                new Decimal(s, { roundingMode: "floor" }).toString()
             ).toStrictEqual("0." + "1".repeat(MAX_SIGNIFICANT_DIGITS));
         });
         test("trunc", () => {
@@ -425,9 +419,7 @@ describe("constructor", () => {
             expect(
                 new Decimal(s, {
                     roundingMode: "trunc",
-                }).toFixed({
-                    digits: Infinity,
-                })
+                }).toString()
             ).toStrictEqual("0." + "1".repeat(MAX_SIGNIFICANT_DIGITS));
         });
         describe("halfEven", () => {
@@ -437,9 +429,7 @@ describe("constructor", () => {
                 let d2 = new Decimal(s, {
                     roundingMode: "halfEven",
                 });
-                expect(d1.toFixed({ digits: Infinity })).toStrictEqual(
-                    d2.toFixed({ digits: Infinity })
-                );
+                expect(d1.toString()).toStrictEqual(d2.toString());
             });
         });
         test("halfExpand", () => {
@@ -447,7 +437,7 @@ describe("constructor", () => {
             expect(
                 new Decimal(s, {
                     roundingMode: "halfExpand",
-                }).toFixed({ digits: Infinity })
+                }).toString()
             ).toStrictEqual(
                 "0." + "1".repeat(MAX_SIGNIFICANT_DIGITS - 1) + "2"
             );

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -1,4 +1,5 @@
 import { Decimal } from "../../src/Decimal.mjs";
+import { CoefficientExponent } from "../../src/CoefficientExponent.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 
@@ -456,6 +457,16 @@ describe("options bag validation", () => {
     });
     test("invalid roundingMode string throws RangeError", () => {
         expect(() => new Decimal("1.5", { roundingMode: "bogus" })).toThrow(
+            RangeError
+        );
+    });
+    test("CoefficientExponent input: non-object options throws TypeError", () => {
+        let ce = new CoefficientExponent(15n, -1, false);
+        expect(() => new Decimal(ce, "ceil")).toThrow(TypeError);
+    });
+    test("CoefficientExponent input: invalid roundingMode string throws RangeError", () => {
+        let ce = new CoefficientExponent(15n, -1, false);
+        expect(() => new Decimal(ce, { roundingMode: "bogus" })).toThrow(
             RangeError
         );
     });

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -6,6 +6,7 @@ import {
     POSITIVE_ZERO,
     NEGATIVE_ZERO,
 } from "./special-values.js";
+import { describeOptionsBagValidation } from "./util.js";
 
 describe("division", () => {
     test("simple example", () => {
@@ -443,21 +444,4 @@ describe("division", () => {
     });
 });
 
-describe("options bag validation", () => {
-    let a = new Decimal("1");
-    let b = new Decimal("2");
-    test("non-object options throws TypeError", () => {
-        expect(() => a.divide(b, "ceil")).toThrow(TypeError);
-    });
-    test("non-string roundingMode throws TypeError", () => {
-        expect(() => a.divide(b, { roundingMode: 42 })).toThrow(TypeError);
-    });
-    test("invalid roundingMode string throws RangeError", () => {
-        expect(() => a.divide(b, { roundingMode: "bogus" })).toThrow(
-            RangeError
-        );
-    });
-    test("unknown keys are ignored", () => {
-        expect(a.divide(b, { digits: 1 }).toString()).toStrictEqual("0.5");
-    });
-});
+describeOptionsBagValidation("divide", "0.5");

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -442,3 +442,22 @@ describe("division", () => {
         });
     });
 });
+
+describe("options bag validation", () => {
+    let a = new Decimal("1");
+    let b = new Decimal("2");
+    test("non-object options throws TypeError", () => {
+        expect(() => a.divide(b, "ceil")).toThrow(TypeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => a.divide(b, { roundingMode: 42 })).toThrow(TypeError);
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => a.divide(b, { roundingMode: "bogus" })).toThrow(
+            RangeError
+        );
+    });
+    test("unknown keys are ignored", () => {
+        expect(a.divide(b, { digits: 1 }).toString()).toStrictEqual("0.5");
+    });
+});

--- a/tests/Decimal/divide.test.js
+++ b/tests/Decimal/divide.test.js
@@ -20,9 +20,7 @@ describe("division", () => {
     });
     test("infinite decimal representation", () => {
         expect(
-            new Decimal("0.11")
-                .divide(new Decimal("0.3"))
-                .toFixed({ digits: Infinity })
+            new Decimal("0.11").divide(new Decimal("0.3")).toString()
         ).toStrictEqual("0.3666666666666666666666666666666667");
     });
     test("many digits, few significant", () => {
@@ -34,9 +32,7 @@ describe("division", () => {
     });
     test("one third", () => {
         expect(
-            new Decimal("1")
-                .divide(new Decimal("3"))
-                .toFixed({ digits: Infinity })
+            new Decimal("1").divide(new Decimal("3")).toString()
         ).toStrictEqual("0.3333333333333333333333333333333333");
     });
     test("one tenth", () => {
@@ -172,16 +168,12 @@ describe("division", () => {
         // some examples have been tweaked because we are working with more precision in Decimal128
         test("example one", () => {
             expect(
-                new Decimal("1")
-                    .divide(new Decimal("3"))
-                    .toFixed({ digits: Infinity })
+                new Decimal("1").divide(new Decimal("3")).toString()
             ).toStrictEqual("0.3333333333333333333333333333333333");
         });
         test("example two", () => {
             expect(
-                new Decimal("2")
-                    .divide(new Decimal("3"))
-                    .toFixed({ digits: Infinity })
+                new Decimal("2").divide(new Decimal("3")).toString()
             ).toStrictEqual("0.6666666666666666666666666666666667");
         });
         test("example three", () => {

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -429,3 +429,22 @@ describe("multiply", () => {
         });
     });
 });
+
+describe("options bag validation", () => {
+    let a = new Decimal("1");
+    let b = new Decimal("2");
+    test("non-object options throws TypeError", () => {
+        expect(() => a.multiply(b, "ceil")).toThrow(TypeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => a.multiply(b, { roundingMode: 42 })).toThrow(TypeError);
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => a.multiply(b, { roundingMode: "bogus" })).toThrow(
+            RangeError
+        );
+    });
+    test("unknown keys are ignored", () => {
+        expect(a.multiply(b, { digits: 1 }).toString()).toStrictEqual("2");
+    });
+});

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -6,6 +6,7 @@ import {
     POSITIVE_ZERO,
     NEGATIVE_ZERO,
 } from "./special-values.js";
+import { describeOptionsBagValidation } from "./util.js";
 
 let posZero = POSITIVE_ZERO;
 let negZero = NEGATIVE_ZERO;
@@ -430,21 +431,4 @@ describe("multiply", () => {
     });
 });
 
-describe("options bag validation", () => {
-    let a = new Decimal("1");
-    let b = new Decimal("2");
-    test("non-object options throws TypeError", () => {
-        expect(() => a.multiply(b, "ceil")).toThrow(TypeError);
-    });
-    test("non-string roundingMode throws TypeError", () => {
-        expect(() => a.multiply(b, { roundingMode: 42 })).toThrow(TypeError);
-    });
-    test("invalid roundingMode string throws RangeError", () => {
-        expect(() => a.multiply(b, { roundingMode: "bogus" })).toThrow(
-            RangeError
-        );
-    });
-    test("unknown keys are ignored", () => {
-        expect(a.multiply(b, { digits: 1 }).toString()).toStrictEqual("2");
-    });
-});
+describeOptionsBagValidation("multiply", "2");

--- a/tests/Decimal/multiply.test.js
+++ b/tests/Decimal/multiply.test.js
@@ -31,8 +31,11 @@ const examples = [
 ];
 
 function checkProduct(a, b, c) {
+    const fractionDigits = (c.split(".")[1] ?? "").length;
     expect(
-        new Decimal(a).multiply(new Decimal(b)).toFixed({ digits: Infinity })
+        new Decimal(a)
+            .multiply(new Decimal(b))
+            .toFixed({ digits: fractionDigits })
     ).toStrictEqual(c);
 }
 
@@ -56,21 +59,21 @@ describe("multiply", () => {
         expect(
             new Decimal("123456789123456789")
                 .multiply(new Decimal("987654321987654321"))
-                .toFixed({ digits: Infinity })
+                .toFixed({ digits: 0 })
         ).toStrictEqual("121932631356500531347203169112635300");
     });
     test("approximation needed (negative)", () => {
         expect(
             new Decimal("123456789123456789")
                 .multiply(new Decimal("-987654321987654321"))
-                .toFixed({ digits: Infinity })
+                .toFixed({ digits: 0 })
         ).toStrictEqual("-121932631356500531347203169112635300");
     });
     test("approximation needed", () => {
         expect(
             new Decimal("123456789123456789.987654321")
                 .multiply(new Decimal("987654321123456789.123456789"))
-                .toFixed({ digits: Infinity })
+                .toFixed({ digits: 0 })
         ).toStrictEqual("121932631249809479868770005427526300");
     });
     describe("zero", () => {

--- a/tests/Decimal/negate.test.js
+++ b/tests/Decimal/negate.test.js
@@ -45,7 +45,7 @@ describe("negate", () => {
     });
     test("limit of digits", () => {
         expect(
-            new Decimal("-" + bigDigits).negate().toFixed({ digits: Infinity })
+            new Decimal("-" + bigDigits).negate().toFixed({ digits: 0 })
         ).toStrictEqual(bigDigits);
     });
 });

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -48,20 +48,24 @@ describe("round", () => {
     });
     describe("round after a certain number of decimal digits", () => {
         test("multiple digits", () => {
-            expect(new Decimal("42.345").round(2).toString()).toStrictEqual(
-                "42.34"
-            );
+            expect(
+                new Decimal("42.345").round({ digits: 2 }).toString()
+            ).toStrictEqual("42.34");
         });
         test("more digits than are available", () => {
-            expect(new Decimal("1.5").round(1).toString()).toStrictEqual("1.5");
+            expect(
+                new Decimal("1.5").round({ digits: 1 }).toString()
+            ).toStrictEqual("1.5");
         });
         test("negative odd", () => {
-            expect(new Decimal("-1.5").round(1).toString()).toStrictEqual(
-                "-1.5"
-            );
+            expect(
+                new Decimal("-1.5").round({ digits: 1 }).toString()
+            ).toStrictEqual("-1.5");
         });
         test("round down (positive)", () => {
-            expect(new Decimal("1.1").round(6).toString()).toStrictEqual("1.1");
+            expect(
+                new Decimal("1.1").round({ digits: 6 }).toString()
+            ).toStrictEqual("1.1");
         });
     });
     test("integer", () => {
@@ -71,36 +75,44 @@ describe("round", () => {
         expect(new Decimal("-42").round().toString()).toStrictEqual("-42");
     });
     test("negative number of digits requested is truncation", () => {
-        expect(() => new Decimal("1.5").round(-42)).toThrow(RangeError);
-        expect(() => new Decimal("1.5").round(-42)).toThrow(
-            "Invalid number of decimal digits"
+        expect(() => new Decimal("1.5").round({ digits: -42 })).toThrow(
+            RangeError
+        );
+        expect(() => new Decimal("1.5").round({ digits: -42 })).toThrow(
+            "digits must be non-negative"
         );
     });
     test("too many digits requested", () => {
-        expect(() => new Decimal("1.5").round(2 ** 53)).toThrow(RangeError);
-        expect(() => new Decimal("1.5").round(2 ** 53)).toThrow(
-            "Too many decimal digits requested"
+        expect(() => new Decimal("1.5").round({ digits: 2 ** 53 })).toThrow(
+            RangeError
+        );
+        expect(() => new Decimal("1.5").round({ digits: 2 ** 53 })).toThrow(
+            "Too many digits requested"
         );
     });
     test("round to zero", () => {
-        expect(new Decimal("0.5").round(0, "trunc").toString()).toStrictEqual(
-            "0"
-        );
+        expect(
+            new Decimal("0.5")
+                .round({ digits: 0, roundingMode: "trunc" })
+                .toString()
+        ).toStrictEqual("0");
     });
     test("round to minus zero", () => {
-        expect(new Decimal("-0.5").round(0, "trunc").toString()).toStrictEqual(
-            "-0"
-        );
+        expect(
+            new Decimal("-0.5")
+                .round({ digits: 0, roundingMode: "trunc" })
+                .toString()
+        ).toStrictEqual("-0");
     });
 
     describe("unsupported rounding mode", () => {
         test("throws", () => {
-            expect(() => new Decimal("1.5").round(0, "foobar")).toThrow(
-                RangeError
-            );
-            expect(() => new Decimal("1.5").round(0, "foobar")).toThrow(
-                'Invalid rounding mode "foobar"'
-            );
+            expect(() =>
+                new Decimal("1.5").round({ digits: 0, roundingMode: "foobar" })
+            ).toThrow(RangeError);
+            expect(() =>
+                new Decimal("1.5").round({ digits: 0, roundingMode: "foobar" })
+            ).toThrow('Invalid rounding mode "foobar"');
         });
     });
 
@@ -113,135 +125,185 @@ describe("round", () => {
         describe("ceil", () => {
             test("-1.5", () => {
                 expect(
-                    minusOnePointFive.round(0, "ceil").toString()
+                    minusOnePointFive
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
                 ).toStrictEqual("-1");
             });
             test("0.4", () => {
-                expect(zeroPointFour.round(0, "ceil").toString()).toStrictEqual(
-                    "1"
-                );
+                expect(
+                    zeroPointFour
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("1");
             });
             test("0.5", () => {
-                expect(zeroPointFive.round(0, "ceil").toString()).toStrictEqual(
-                    "1"
-                );
+                expect(
+                    zeroPointFive
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("1");
             });
             test("0.6", () => {
-                expect(zeroPointSix.round(0, "ceil").toString()).toStrictEqual(
-                    "1"
-                );
+                expect(
+                    zeroPointSix
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("1");
             });
             test("1.5", () => {
-                expect(onePointFive.round(0, "ceil").toString()).toStrictEqual(
-                    "2"
-                );
+                expect(
+                    onePointFive
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("2");
             });
         });
         describe("floor", () => {
             test("-1.5", () => {
                 expect(
-                    minusOnePointFive.round(0, "floor").toString()
+                    minusOnePointFive
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
                 ).toStrictEqual("-2");
             });
             test("0.4", () => {
                 expect(
-                    zeroPointFour.round(0, "floor").toString()
+                    zeroPointFour
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.5", () => {
                 expect(
-                    zeroPointFive.round(0, "floor").toString()
+                    zeroPointFive
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.6", () => {
-                expect(zeroPointSix.round(0, "floor").toString()).toStrictEqual(
-                    "0"
-                );
+                expect(
+                    zeroPointSix
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
+                ).toStrictEqual("0");
             });
             test("1.5", () => {
-                expect(onePointFive.round(0, "floor").toString()).toStrictEqual(
-                    "1"
-                );
+                expect(
+                    onePointFive
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
+                ).toStrictEqual("1");
             });
         });
         describe("trunc", () => {
             test("-1.5", () => {
                 expect(
-                    minusOnePointFive.round(0, "trunc").toString()
+                    minusOnePointFive
+                        .round({ digits: 0, roundingMode: "trunc" })
+                        .toString()
                 ).toStrictEqual("-1");
             });
             test("0.4", () => {
                 expect(
-                    zeroPointFour.round(0, "trunc").toString()
+                    zeroPointFour
+                        .round({ digits: 0, roundingMode: "trunc" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.5", () => {
                 expect(
-                    zeroPointFive.round(0, "trunc").toString()
+                    zeroPointFive
+                        .round({ digits: 0, roundingMode: "trunc" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.6", () => {
-                expect(zeroPointSix.round(0, "trunc").toString()).toStrictEqual(
-                    "0"
-                );
+                expect(
+                    zeroPointSix
+                        .round({ digits: 0, roundingMode: "trunc" })
+                        .toString()
+                ).toStrictEqual("0");
             });
             test("1.5", () => {
-                expect(onePointFive.round(0, "trunc").toString()).toStrictEqual(
-                    "1"
-                );
+                expect(
+                    onePointFive
+                        .round({ digits: 0, roundingMode: "trunc" })
+                        .toString()
+                ).toStrictEqual("1");
             });
         });
         describe("halfExpand", () => {
             test("-1.5", () => {
                 expect(
-                    minusOnePointFive.round(0, "halfExpand").toString()
+                    minusOnePointFive
+                        .round({ digits: 0, roundingMode: "halfExpand" })
+                        .toString()
                 ).toStrictEqual("-2");
             });
             test("0.4", () => {
                 expect(
-                    zeroPointFour.round(0, "halfExpand").toString()
+                    zeroPointFour
+                        .round({ digits: 0, roundingMode: "halfExpand" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.5", () => {
                 expect(
-                    zeroPointFive.round(0, "halfExpand").toString()
+                    zeroPointFive
+                        .round({ digits: 0, roundingMode: "halfExpand" })
+                        .toString()
                 ).toStrictEqual("1");
             });
             test("0.6", () => {
                 expect(
-                    zeroPointSix.round(0, "halfExpand").toString()
+                    zeroPointSix
+                        .round({ digits: 0, roundingMode: "halfExpand" })
+                        .toString()
                 ).toStrictEqual("1");
             });
             test("1.5", () => {
                 expect(
-                    onePointFive.round(0, "halfExpand").toString()
+                    onePointFive
+                        .round({ digits: 0, roundingMode: "halfExpand" })
+                        .toString()
                 ).toStrictEqual("2");
             });
         });
         describe("halfEven", () => {
             test("-1.5", () => {
                 expect(
-                    minusOnePointFive.round(0, "halfEven").toString()
+                    minusOnePointFive
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
                 ).toStrictEqual("-2");
             });
             test("0.4", () => {
                 expect(
-                    zeroPointFour.round(0, "halfEven").toString()
+                    zeroPointFour
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.5", () => {
                 expect(
-                    zeroPointFive.round(0, "halfEven").toString()
+                    zeroPointFive
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
                 ).toStrictEqual("0");
             });
             test("0.6", () => {
                 expect(
-                    zeroPointSix.round(0, "halfEven").toString()
+                    zeroPointSix
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
                 ).toStrictEqual("1");
             });
             test("1.5", () => {
                 expect(
-                    onePointFive.round(0, "halfEven").toString()
+                    onePointFive
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
                 ).toStrictEqual("2");
             });
         });
@@ -257,7 +319,9 @@ describe("round", () => {
             for (let roundingMode of ROUNDING_MODES) {
                 test(`positive infinity (${roundingMode})`, () => {
                     expect(
-                        posInf.round(0, roundingMode).toString()
+                        posInf
+                            .round({ digits: 0, roundingMode: roundingMode })
+                            .toString()
                     ).toStrictEqual("Infinity");
                 });
             }
@@ -267,15 +331,21 @@ describe("round", () => {
             for (let roundingMode of ROUNDING_MODES) {
                 test(`negative infinity (${roundingMode})`, () => {
                     expect(
-                        negInf.round(0, roundingMode).toString()
+                        negInf
+                            .round({ digits: 0, roundingMode: roundingMode })
+                            .toString()
                     ).toStrictEqual("-Infinity");
                 });
             }
             test("rounding positive a certain number of digits makes no difference", () => {
-                expect(posInf.round(2).toString()).toStrictEqual("Infinity");
+                expect(posInf.round({ digits: 2 }).toString()).toStrictEqual(
+                    "Infinity"
+                );
             });
             test("rounding negative infinity a certain number of digits makes no difference", () => {
-                expect(negInf.round(2).toString()).toStrictEqual("-Infinity");
+                expect(negInf.round({ digits: 2 }).toString()).toStrictEqual(
+                    "-Infinity"
+                );
             });
         });
     });
@@ -283,31 +353,45 @@ describe("round", () => {
     describe("ceiling", function () {
         test("ceiling works (positive)", () => {
             expect(
-                new Decimal("123.456").round(0, "ceil").toString()
+                new Decimal("123.456")
+                    .round({ digits: 0, roundingMode: "ceil" })
+                    .toString()
             ).toStrictEqual("124");
         });
         test("ceiling works (negative)", () => {
             expect(
-                new Decimal("-123.456").round(0, "ceil").toString()
+                new Decimal("-123.456")
+                    .round({ digits: 0, roundingMode: "ceil" })
+                    .toString()
             ).toStrictEqual("-123");
         });
         test("ceiling of an integer is unchanged", () => {
             expect(
-                new Decimal("123").round(0, "ceil").toString()
+                new Decimal("123")
+                    .round({ digits: 0, roundingMode: "ceil" })
+                    .toString()
             ).toStrictEqual("123");
         });
         test("NaN", () => {
-            expect(NAN.round(0, "ceil").toString()).toStrictEqual("NaN");
+            expect(
+                NAN.round({ digits: 0, roundingMode: "ceil" }).toString()
+            ).toStrictEqual("NaN");
         });
         test("positive infinity", () => {
-            expect(POSITIVE_INFINITY.round(0, "ceil").toString()).toStrictEqual(
-                "Infinity"
-            );
+            expect(
+                POSITIVE_INFINITY.round({
+                    digits: 0,
+                    roundingMode: "ceil",
+                }).toString()
+            ).toStrictEqual("Infinity");
         });
         test("minus infinity", () => {
-            expect(NEGATIVE_INFINITY.round(0, "ceil").toString()).toStrictEqual(
-                "-Infinity"
-            );
+            expect(
+                NEGATIVE_INFINITY.round({
+                    digits: 0,
+                    roundingMode: "ceil",
+                }).toString()
+            ).toStrictEqual("-Infinity");
         });
     });
 
@@ -315,33 +399,53 @@ describe("round", () => {
         describe("truncate", () => {
             test("123.45678", () => {
                 expectDecimal128(
-                    new Decimal("123.45678").round(0, "trunc"),
+                    new Decimal("123.45678").round({
+                        digits: 0,
+                        roundingMode: "trunc",
+                    }),
                     "123"
                 );
             });
             test("-42.99", () => {
                 expectDecimal128(
-                    new Decimal("-42.99").round(0, "trunc"),
+                    new Decimal("-42.99").round({
+                        digits: 0,
+                        roundingMode: "trunc",
+                    }),
                     "-42"
                 );
             });
             test("0.00765", () => {
-                expectDecimal128(new Decimal("0.00765").round(0, "trunc"), "0");
+                expectDecimal128(
+                    new Decimal("0.00765").round({
+                        digits: 0,
+                        roundingMode: "trunc",
+                    }),
+                    "0"
+                );
             });
             test("NaN", () => {
-                expect(NAN.round(0, "trunc").toString()).toStrictEqual("NaN");
+                expect(
+                    NAN.round({ digits: 0, roundingMode: "trunc" }).toString()
+                ).toStrictEqual("NaN");
             });
         });
 
         describe("infinity", () => {
             test("positive infinity", () => {
                 expect(
-                    POSITIVE_INFINITY.round(0, "trunc").toString()
+                    POSITIVE_INFINITY.round({
+                        digits: 0,
+                        roundingMode: "trunc",
+                    }).toString()
                 ).toStrictEqual("Infinity");
             });
             test("negative infinity", () => {
                 expect(
-                    NEGATIVE_INFINITY.round(0, "trunc").toString()
+                    NEGATIVE_INFINITY.round({
+                        digits: 0,
+                        roundingMode: "trunc",
+                    }).toString()
                 ).toStrictEqual("-Infinity");
             });
         });
@@ -350,35 +454,52 @@ describe("round", () => {
     describe("floor", function () {
         test("floor works (positive)", () => {
             expect(
-                new Decimal("123.456").round(0, "floor").toString()
+                new Decimal("123.456")
+                    .round({ digits: 0, roundingMode: "floor" })
+                    .toString()
             ).toStrictEqual("123");
         });
         test("floor works (negative)", () => {
             expect(
-                new Decimal("-123.456").round(0, "floor").toString()
+                new Decimal("-123.456")
+                    .round({ digits: 0, roundingMode: "floor" })
+                    .toString()
             ).toStrictEqual("-124");
         });
         test("floor of integer is unchanged", () => {
             expect(
-                new Decimal("123").round(0, "floor").toString()
+                new Decimal("123")
+                    .round({ digits: 0, roundingMode: "floor" })
+                    .toString()
             ).toStrictEqual("123");
         });
         test("floor of zero is unchanged", () => {
-            expect(POSITIVE_ZERO.round(0, "floor").toString()).toStrictEqual(
-                "0"
-            );
+            expect(
+                POSITIVE_ZERO.round({
+                    digits: 0,
+                    roundingMode: "floor",
+                }).toString()
+            ).toStrictEqual("0");
         });
         test("NaN", () => {
-            expect(NAN.round(0, "floor").toString()).toStrictEqual("NaN");
+            expect(
+                NAN.round({ digits: 0, roundingMode: "floor" }).toString()
+            ).toStrictEqual("NaN");
         });
         test("positive infinity", () => {
             expect(
-                POSITIVE_INFINITY.round(0, "floor").toString()
+                POSITIVE_INFINITY.round({
+                    digits: 0,
+                    roundingMode: "floor",
+                }).toString()
             ).toStrictEqual("Infinity");
         });
         test("minus infinity", () => {
             expect(
-                NEGATIVE_INFINITY.round(0, "floor").toString()
+                NEGATIVE_INFINITY.round({
+                    digits: 0,
+                    roundingMode: "floor",
+                }).toString()
             ).toStrictEqual("-Infinity");
         });
     });
@@ -386,39 +507,55 @@ describe("round", () => {
     describe("examples for TC39 plenary slides", () => {
         let a = new Decimal("1.456");
         test("round to 2 decimal places, rounding mode is ceiling", () => {
-            expect(a.round(2, "ceil").toString()).toStrictEqual("1.46");
+            expect(
+                a.round({ digits: 2, roundingMode: "ceil" }).toString()
+            ).toStrictEqual("1.46");
         });
         test("round to 1 decimal place, rounding mode unspecified", () => {
-            expect(a.round(1).toString()).toStrictEqual("1.5");
-            expect(a.round(1, "halfEven").toString()).toStrictEqual("1.5");
+            expect(a.round({ digits: 1 }).toString()).toStrictEqual("1.5");
+            expect(
+                a.round({ digits: 1, roundingMode: "halfEven" }).toString()
+            ).toStrictEqual("1.5");
         });
         test("round to 0 decimal places, rounding mode is floor", () => {
-            expect(a.round(0, "floor").toString()).toStrictEqual("1");
+            expect(
+                a.round({ digits: 0, roundingMode: "floor" }).toString()
+            ).toStrictEqual("1");
         });
     });
 
     describe("halfEven ties whose even neighbor ends in a trailing zero", () => {
         test("10.5 rounds down to 10", () => {
             expect(
-                new Decimal("10.5").round(0, "halfEven").toString()
+                new Decimal("10.5")
+                    .round({ digits: 0, roundingMode: "halfEven" })
+                    .toString()
             ).toStrictEqual("10");
         });
         test("-10.5 rounds up to -10", () => {
             expect(
-                new Decimal("-10.5").round(0, "halfEven").toString()
+                new Decimal("-10.5")
+                    .round({ digits: 0, roundingMode: "halfEven" })
+                    .toString()
             ).toStrictEqual("-10");
         });
         test("1.05 rounds down to 1.0 at one decimal place", () => {
             expect(
-                new Decimal("1.05").round(1, "halfEven").toString()
+                new Decimal("1.05")
+                    .round({ digits: 1, roundingMode: "halfEven" })
+                    .toString()
             ).toStrictEqual("1");
         });
         test("10.5 rounds down to 10 under the default mode", () => {
-            expect(new Decimal("10.5").round(0).toString()).toStrictEqual("10");
+            expect(
+                new Decimal("10.5").round({ digits: 0 }).toString()
+            ).toStrictEqual("10");
         });
         test("30.5 rounds down to 30", () => {
             expect(
-                new Decimal("30.5").round(0, "halfEven").toString()
+                new Decimal("30.5")
+                    .round({ digits: 0, roundingMode: "halfEven" })
+                    .toString()
             ).toStrictEqual("30");
         });
     });
@@ -440,25 +577,31 @@ describe("round", () => {
                     "9.999999999999999999999999999999999E+6144"
                 );
                 // Rounding with ceiling when already at max
-                expect(nearMax.round(30, "ceil").toString()).toStrictEqual(
-                    "9.999999999999999999999999999999999e+6144"
-                );
+                expect(
+                    nearMax
+                        .round({ digits: 30, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("9.999999999999999999999999999999999e+6144");
             });
 
             test("round minimum normal value", () => {
                 const minNormal = new Decimal("1E-6143");
                 // Rounding to 0 decimals truncates to 0
-                expect(minNormal.round(0).toString()).toStrictEqual("0");
-                // But with many decimals preserves the value
-                expect(minNormal.round(6143).toString()).toStrictEqual(
-                    "1e-6143"
+                expect(minNormal.round({ digits: 0 }).toString()).toStrictEqual(
+                    "0"
                 );
+                // But with many decimals preserves the value
+                expect(
+                    minNormal.round({ digits: 6143 }).toString()
+                ).toStrictEqual("1e-6143");
             });
 
             test("round subnormal values", () => {
                 const subnormal = new Decimal("1E-6150");
                 // Currently normalizes to E-6143 but rounding to 6143 decimals gives 0
-                expect(subnormal.round(6143).toString()).toStrictEqual("0");
+                expect(
+                    subnormal.round({ digits: 6143 }).toString()
+                ).toStrictEqual("0");
             });
         });
 
@@ -468,7 +611,7 @@ describe("round", () => {
                     "1.234567890123456789012345678901234E+6144"
                 );
                 // Rounding to 30 decimal places (which don't exist at this magnitude)
-                expect(val.round(30).toString()).toStrictEqual(
+                expect(val.round({ digits: 30 }).toString()).toStrictEqual(
                     "1.234567890123456789012345678901234e+6144"
                 );
             });
@@ -478,43 +621,55 @@ describe("round", () => {
                     "1.234567890123456789012345678901234E-6143"
                 );
                 // Round to 6140 decimal places - underflows to 0
-                expect(tiny.round(6140).toString()).toStrictEqual("0");
+                expect(tiny.round({ digits: 6140 }).toString()).toStrictEqual(
+                    "0"
+                );
             });
         });
 
         describe("rounding modes at boundaries", () => {
             test("floor rounding near zero boundary", () => {
                 const tiny = new Decimal("9E-6144");
-                expect(tiny.round(6143, "floor").toString()).toStrictEqual("0");
+                expect(
+                    tiny
+                        .round({ digits: 6143, roundingMode: "floor" })
+                        .toString()
+                ).toStrictEqual("0");
             });
 
             test("ceiling rounding near zero boundary", () => {
                 const tiny = new Decimal("1E-6144");
-                expect(tiny.round(6143, "ceil").toString()).toStrictEqual(
-                    "1e-6143"
-                );
+                expect(
+                    tiny
+                        .round({ digits: 6143, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("1e-6143");
             });
 
             test("halfEven rounding at extreme", () => {
                 const val = new Decimal("5.5E+6143");
                 // Large values don't have fractional parts at this magnitude
-                expect(val.round(0, "halfEven").toString()).toStrictEqual(
-                    "5.5e+6143"
-                );
+                expect(
+                    val
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
+                ).toStrictEqual("5.5e+6143");
 
                 const val2 = new Decimal("4.5E+6143");
-                expect(val2.round(0, "halfEven").toString()).toStrictEqual(
-                    "4.5e+6143"
-                );
+                expect(
+                    val2
+                        .round({ digits: 0, roundingMode: "halfEven" })
+                        .toString()
+                ).toStrictEqual("4.5e+6143");
             });
 
             test("truncate at maximum", () => {
                 const max = new Decimal(
                     "9.999999999999999999999999999999999E+6144"
                 );
-                expect(max.round(0, "trunc").toString()).toStrictEqual(
-                    "9.999999999999999999999999999999999e+6144"
-                );
+                expect(
+                    max.round({ digits: 0, roundingMode: "trunc" }).toString()
+                ).toStrictEqual("9.999999999999999999999999999999999e+6144");
             });
         });
 
@@ -522,7 +677,7 @@ describe("round", () => {
             test("round to very large number of decimal places", () => {
                 const val = new Decimal("1.23456789");
                 // Rounding to 1000000 decimal places
-                expect(val.round(1000000).toString()).toStrictEqual(
+                expect(val.round({ digits: 1000000 }).toString()).toStrictEqual(
                     "1.23456789"
                 );
             });
@@ -532,7 +687,7 @@ describe("round", () => {
                     "9.999999999999999999999999999999999E+6144"
                 );
                 // Cannot have decimal places at this magnitude
-                expect(extreme.round(100).toString()).toStrictEqual(
+                expect(extreme.round({ digits: 100 }).toString()).toStrictEqual(
                     "9.999999999999999999999999999999999e+6144"
                 );
             });
@@ -540,7 +695,9 @@ describe("round", () => {
             test("round with maximum allowed decimal places", () => {
                 const val = new Decimal("1.5");
                 // Test with very large but valid number
-                expect(val.round(1e9).toString()).toStrictEqual("1.5");
+                expect(val.round({ digits: 1e9 }).toString()).toStrictEqual(
+                    "1.5"
+                );
             });
         });
 
@@ -548,15 +705,19 @@ describe("round", () => {
             test("round negative zero", () => {
                 const negZero = NEGATIVE_ZERO;
                 expect(negZero.round().toString()).toStrictEqual("-0");
-                expect(negZero.round(5).toString()).toStrictEqual("-0");
+                expect(negZero.round({ digits: 5 }).toString()).toStrictEqual(
+                    "-0"
+                );
             });
 
             test("round value that becomes zero", () => {
                 const tiny = new Decimal("0.00001");
-                expect(tiny.round(4).toString()).toStrictEqual("0");
+                expect(tiny.round({ digits: 4 }).toString()).toStrictEqual("0");
 
                 const negTiny = new Decimal("-0.00001");
-                expect(negTiny.round(4).toString()).toStrictEqual("-0");
+                expect(negTiny.round({ digits: 4 }).toString()).toStrictEqual(
+                    "-0"
+                );
             });
 
             test("round at the edge of representable precision", () => {
@@ -565,11 +726,11 @@ describe("round", () => {
                     "1.234567890123456789012345678901234"
                 );
                 // Round to 33 decimal places
-                expect(precise.round(33).toString()).toStrictEqual(
+                expect(precise.round({ digits: 33 }).toString()).toStrictEqual(
                     "1.234567890123456789012345678901234"
                 );
                 // Round to 32 decimal places - loses last digit
-                expect(precise.round(32).toString()).toStrictEqual(
+                expect(precise.round({ digits: 32 }).toString()).toStrictEqual(
                     "1.23456789012345678901234567890123"
                 );
             });
@@ -581,26 +742,78 @@ describe("round", () => {
                     "9.999999999999999999999999999999999E+6144"
                 );
                 // Even with ceiling, stays at max
-                expect(nearMax.round(0, "ceil").toString()).toStrictEqual(
-                    "9.999999999999999999999999999999999e+6144"
-                );
+                expect(
+                    nearMax
+                        .round({ digits: 0, roundingMode: "ceil" })
+                        .toString()
+                ).toStrictEqual("9.999999999999999999999999999999999e+6144");
             });
 
             test("round can cause underflow to zero", () => {
                 const verySmall = new Decimal("4.99999E-6144");
                 // Floor rounding to integer underflows to 0
-                expect(verySmall.round(0, "floor").toString()).toStrictEqual(
-                    "0"
-                );
+                expect(
+                    verySmall
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
+                ).toStrictEqual("0");
             });
 
             test("round preserves sign when underflowing", () => {
                 const negSmall = new Decimal("-4.99999E-6144");
                 // Floor rounding to integer gives -1
-                expect(negSmall.round(0, "floor").toString()).toStrictEqual(
-                    "-1"
-                );
+                expect(
+                    negSmall
+                        .round({ digits: 0, roundingMode: "floor" })
+                        .toString()
+                ).toStrictEqual("-1");
             });
         });
+    });
+});
+
+describe("options bag validation", () => {
+    let d = new Decimal("1.25");
+    test("positional number argument throws TypeError", () => {
+        expect(() => d.round(2)).toThrow(TypeError);
+    });
+    test("positional digits-and-mode arguments throw TypeError", () => {
+        expect(() => d.round(2, "ceil")).toThrow(TypeError);
+    });
+    test("null options throws TypeError", () => {
+        expect(() => d.round(null)).toThrow(TypeError);
+    });
+    test("string options throws TypeError", () => {
+        expect(() => d.round("ceil")).toThrow(TypeError);
+    });
+    test("non-number digits throws TypeError", () => {
+        expect(() => d.round({ digits: "2" })).toThrow(TypeError);
+    });
+    test("NaN digits throws RangeError", () => {
+        expect(() => d.round({ digits: NaN })).toThrow(RangeError);
+    });
+    test("infinite digits throws RangeError", () => {
+        expect(() => d.round({ digits: Infinity })).toThrow(RangeError);
+    });
+    test("non-integer digits throws RangeError", () => {
+        expect(() => d.round({ digits: 1.5 })).toThrow(RangeError);
+    });
+    test("negative digits throws RangeError", () => {
+        expect(() => d.round({ digits: -1 })).toThrow(RangeError);
+    });
+    test("too many digits throws RangeError", () => {
+        expect(() => d.round({ digits: 1e9 + 1 })).toThrow(RangeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => d.round({ roundingMode: 42 })).toThrow(TypeError);
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => d.round({ roundingMode: "bogus" })).toThrow(RangeError);
+    });
+    test("unknown keys are ignored", () => {
+        expect(d.round({ digitz: 0 }).toString()).toStrictEqual("1");
+    });
+    test("bag with only roundingMode rounds to zero fractional digits", () => {
+        expect(d.round({ roundingMode: "ceil" }).toString()).toStrictEqual("2");
     });
 });

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -676,8 +676,7 @@ describe("round", () => {
         describe("rounding with extreme decimal places", () => {
             test("round to very large number of decimal places", () => {
                 const val = new Decimal("1.23456789");
-                // Rounding to 1000000 decimal places
-                expect(val.round({ digits: 1000000 }).toString()).toStrictEqual(
+                expect(val.round({ digits: 9999 }).toString()).toStrictEqual(
                     "1.23456789"
                 );
             });
@@ -694,8 +693,7 @@ describe("round", () => {
 
             test("round with maximum allowed decimal places", () => {
                 const val = new Decimal("1.5");
-                // Test with very large but valid number
-                expect(val.round({ digits: 1e9 }).toString()).toStrictEqual(
+                expect(val.round({ digits: 10000 }).toString()).toStrictEqual(
                     "1.5"
                 );
             });
@@ -802,7 +800,7 @@ describe("options bag validation", () => {
         expect(() => d.round({ digits: -1 })).toThrow(RangeError);
     });
     test("too many digits throws RangeError", () => {
-        expect(() => d.round({ digits: 1e9 + 1 })).toThrow(RangeError);
+        expect(() => d.round({ digits: 10001 })).toThrow(RangeError);
     });
     test("non-string roundingMode throws TypeError", () => {
         expect(() => d.round({ roundingMode: 42 })).toThrow(TypeError);

--- a/tests/Decimal/round.test.js
+++ b/tests/Decimal/round.test.js
@@ -74,7 +74,7 @@ describe("round", () => {
     test("negative integer", () => {
         expect(new Decimal("-42").round().toString()).toStrictEqual("-42");
     });
-    test("negative number of digits requested is truncation", () => {
+    test("negative number of digits requested throws", () => {
         expect(() => new Decimal("1.5").round({ digits: -42 })).toThrow(
             RangeError
         );

--- a/tests/Decimal/subtract.test.js
+++ b/tests/Decimal/subtract.test.js
@@ -6,7 +6,7 @@ import {
     POSITIVE_ZERO,
     NEGATIVE_ZERO,
 } from "./special-values.js";
-import { expectDecimal128 } from "./util.js";
+import { describeOptionsBagValidation, expectDecimal128 } from "./util.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 let bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
@@ -370,21 +370,4 @@ describe("subtract", () => {
     });
 });
 
-describe("options bag validation", () => {
-    let a = new Decimal("1");
-    let b = new Decimal("2");
-    test("non-object options throws TypeError", () => {
-        expect(() => a.subtract(b, "ceil")).toThrow(TypeError);
-    });
-    test("non-string roundingMode throws TypeError", () => {
-        expect(() => a.subtract(b, { roundingMode: 42 })).toThrow(TypeError);
-    });
-    test("invalid roundingMode string throws RangeError", () => {
-        expect(() => a.subtract(b, { roundingMode: "bogus" })).toThrow(
-            RangeError
-        );
-    });
-    test("unknown keys are ignored", () => {
-        expect(a.subtract(b, { digits: 1 }).toString()).toStrictEqual("-1");
-    });
-});
+describeOptionsBagValidation("subtract", "-1");

--- a/tests/Decimal/subtract.test.js
+++ b/tests/Decimal/subtract.test.js
@@ -369,3 +369,22 @@ describe("subtract", () => {
         });
     });
 });
+
+describe("options bag validation", () => {
+    let a = new Decimal("1");
+    let b = new Decimal("2");
+    test("non-object options throws TypeError", () => {
+        expect(() => a.subtract(b, "ceil")).toThrow(TypeError);
+    });
+    test("non-string roundingMode throws TypeError", () => {
+        expect(() => a.subtract(b, { roundingMode: 42 })).toThrow(TypeError);
+    });
+    test("invalid roundingMode string throws RangeError", () => {
+        expect(() => a.subtract(b, { roundingMode: "bogus" })).toThrow(
+            RangeError
+        );
+    });
+    test("unknown keys are ignored", () => {
+        expect(a.subtract(b, { digits: 1 }).toString()).toStrictEqual("-1");
+    });
+});

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -83,6 +83,16 @@ describe("toExponential", () => {
             "digits must be an integer"
         );
     });
+    test("maximum number of digits works", () => {
+        expect(new Decimal("0").toExponential({ digits: 10000 })).toStrictEqual(
+            "0." + "0".repeat(10000) + "e+0"
+        );
+    });
+    test("too many digits requested throws", () => {
+        expect(() => decimalD.toExponential({ digits: 10001 })).toThrow(
+            "Too many digits requested"
+        );
+    });
     describe("negative", () => {
         let negD = decimalD.negate();
         test("integer part", () => {

--- a/tests/Decimal/toexponential.test.js
+++ b/tests/Decimal/toexponential.test.js
@@ -67,11 +67,8 @@ describe("toExponential", () => {
     test("fewer digits requested than available rounds (3)", () => {
         expectDecimal128(decimalD.toExponential({ digits: 1 }), "1.2e+2");
     });
-    test("zero decimal places throws", () => {
-        expect(() => decimalD.toExponential({ digits: 0 })).toThrow(RangeError);
-        expect(() => decimalD.toExponential({ digits: 0 })).toThrow(
-            "Argument must be positive"
-        );
+    test("zero decimal places rounds the mantissa to an integer", () => {
+        expect(decimalD.toExponential({ digits: 0 })).toStrictEqual("1e+2");
     });
     test("negative number of decimal places", () => {
         expect(() => decimalD.toExponential({ digits: -1 })).toThrow(
@@ -83,7 +80,7 @@ describe("toExponential", () => {
             RangeError
         );
         expect(() => decimalD.toExponential({ digits: 1.5 })).toThrow(
-            "Argument must be an integer"
+            "digits must be an integer"
         );
     });
     describe("negative", () => {
@@ -235,5 +232,73 @@ describe("toExponential", () => {
                 "-1.5e-6160"
             );
         });
+    });
+});
+
+describe("digits: 0 (Number precedent)", () => {
+    test("rounds mantissa to an integer", () => {
+        expect(new Decimal("1.25").toExponential({ digits: 0 })).toStrictEqual(
+            "1e+0"
+        );
+    });
+    test("zero", () => {
+        expect(new Decimal("0").toExponential({ digits: 0 })).toStrictEqual(
+            "0e+0"
+        );
+    });
+    test("carry out of the mantissa range", () => {
+        expect(new Decimal("9.9").toExponential({ digits: 0 })).toStrictEqual(
+            "1e+1"
+        );
+    });
+});
+
+describe("roundingMode", () => {
+    test("default is halfEven", () => {
+        expect(
+            new Decimal("1.25e5").toExponential({ digits: 1 })
+        ).toStrictEqual("1.2e+5");
+    });
+    test("halfExpand", () => {
+        expect(
+            new Decimal("1.25e5").toExponential({
+                digits: 1,
+                roundingMode: "halfExpand",
+            })
+        ).toStrictEqual("1.3e+5");
+    });
+    test("ceil on a negative value rounds toward zero", () => {
+        expect(
+            new Decimal("-1.29e5").toExponential({
+                digits: 1,
+                roundingMode: "ceil",
+            })
+        ).toStrictEqual("-1.2e+5");
+    });
+    test("floor on a negative value rounds away from zero", () => {
+        expect(
+            new Decimal("-1.21e5").toExponential({
+                digits: 1,
+                roundingMode: "floor",
+            })
+        ).toStrictEqual("-1.3e+5");
+    });
+    test("carry after directed rounding", () => {
+        expect(
+            new Decimal("9.99").toExponential({
+                digits: 1,
+                roundingMode: "ceil",
+            })
+        ).toStrictEqual("1.0e+1");
+    });
+    test("invalid roundingMode throws RangeError", () => {
+        expect(() =>
+            new Decimal("1.25").toExponential({ roundingMode: "bogus" })
+        ).toThrow(RangeError);
+    });
+    test("options are validated even for NaN receivers", () => {
+        expect(() => new Decimal("NaN").toExponential("junk")).toThrow(
+            TypeError
+        );
     });
 });

--- a/tests/Decimal/tofixed.test.js
+++ b/tests/Decimal/tofixed.test.js
@@ -95,6 +95,19 @@ describe("toFixed", () => {
                 "42.0000000000"
             );
         });
+        test("maximum number of digits works", () => {
+            expect(new Decimal("1").toFixed({ digits: 10000 })).toStrictEqual(
+                "1." + "0".repeat(10000)
+            );
+        });
+        test("too many digits requested throws", () => {
+            expect(() => decimalD.toFixed({ digits: 10001 })).toThrow(
+                RangeError
+            );
+            expect(() => decimalD.toFixed({ digits: 10001 })).toThrow(
+                "Too many digits requested"
+            );
+        });
     });
     describe("bare call follows Number precedent", () => {
         test("digits defaults to 0", () => {

--- a/tests/Decimal/tofixed.test.js
+++ b/tests/Decimal/tofixed.test.js
@@ -43,15 +43,6 @@ describe("toFixed", () => {
     describe("to decimal places", function () {
         const d = "123.456";
         const decimalD = new Decimal(d);
-        test("no argument", () => {
-            expectDecimal128(decimalD.toFixed(), "123.456");
-        });
-        test("digits option is present but value is undefined", () => {
-            expectDecimal128(
-                decimalD.toFixed({ digits: undefined }),
-                "123.456"
-            );
-        });
         test("more digits than available means digits get added", () => {
             expectDecimal128(decimalD.toFixed({ digits: 4 }), "123.4560");
         });
@@ -79,13 +70,18 @@ describe("toFixed", () => {
         test("negative number of decimal places throws", () => {
             expect(() => decimalD.toFixed({ digits: -1 })).toThrow(RangeError);
             expect(() => decimalD.toFixed({ digits: -1 })).toThrow(
-                "Argument must be greater than or equal to 0"
+                "digits must be non-negative"
             );
         });
         test("non-integer does not take floor", () => {
             expect(() => decimalD.toFixed({ digits: 1.5 })).toThrow(RangeError);
             expect(() => decimalD.toFixed({ digits: 1.5 })).toThrow(
-                "Argument must be an integer or positive infinity"
+                "digits must be an integer"
+            );
+        });
+        test("infinite digits throws RangeError", () => {
+            expect(() => decimalD.toFixed({ digits: Infinity })).toThrow(
+                RangeError
             );
         });
         test("non-object argument", () => {
@@ -98,6 +94,77 @@ describe("toFixed", () => {
             expect(new Decimal("42").toFixed({ digits: 10 })).toStrictEqual(
                 "42.0000000000"
             );
+        });
+    });
+    describe("bare call follows Number precedent", () => {
+        test("digits defaults to 0", () => {
+            expect(new Decimal("1.25").toFixed()).toStrictEqual("1");
+        });
+        test("empty bag also defaults to 0", () => {
+            expect(new Decimal("1.75").toFixed({})).toStrictEqual("2");
+        });
+        test("digits option is present but value is undefined", () => {
+            expectDecimal128(
+                new Decimal("123.456").toFixed({ digits: undefined }),
+                "123"
+            );
+        });
+        test("large values stay in plain notation", () => {
+            expect(new Decimal("1e21").toFixed()).toStrictEqual(
+                "1000000000000000000000"
+            );
+        });
+    });
+    describe("roundingMode", () => {
+        test("default is halfEven", () => {
+            expect(new Decimal("1.25").toFixed({ digits: 1 })).toStrictEqual(
+                "1.2"
+            );
+        });
+        test("halfExpand", () => {
+            expect(
+                new Decimal("1.25").toFixed({
+                    digits: 1,
+                    roundingMode: "halfExpand",
+                })
+            ).toStrictEqual("1.3");
+        });
+        test("ceil on a positive value rounds away from zero", () => {
+            expect(
+                new Decimal("1.21").toFixed({ digits: 1, roundingMode: "ceil" })
+            ).toStrictEqual("1.3");
+        });
+        test("ceil on a negative value rounds toward zero", () => {
+            expect(
+                new Decimal("-1.29").toFixed({
+                    digits: 1,
+                    roundingMode: "ceil",
+                })
+            ).toStrictEqual("-1.2");
+        });
+        test("floor on a negative value rounds away from zero", () => {
+            expect(
+                new Decimal("-1.21").toFixed({
+                    digits: 1,
+                    roundingMode: "floor",
+                })
+            ).toStrictEqual("-1.3");
+        });
+        test("trunc drops excess digits", () => {
+            expect(
+                new Decimal("1.29").toFixed({
+                    digits: 1,
+                    roundingMode: "trunc",
+                })
+            ).toStrictEqual("1.2");
+        });
+        test("invalid roundingMode throws RangeError", () => {
+            expect(() =>
+                new Decimal("1.25").toFixed({ roundingMode: "bogus" })
+            ).toThrow(RangeError);
+        });
+        test("options are validated even for NaN receivers", () => {
+            expect(() => new Decimal("NaN").toFixed("junk")).toThrow(TypeError);
         });
     });
 });

--- a/tests/Decimal/toprecision.test.js
+++ b/tests/Decimal/toprecision.test.js
@@ -101,7 +101,7 @@ describe("toPrecision", () => {
                 RangeError
             );
             expect(() => d.toPrecision({ digits: 1.72 }).toString()).toThrow(
-                "Argument must be an integer"
+                "digits must be an integer"
             );
         });
         test("negative integer number of digits requested", () => {
@@ -109,7 +109,7 @@ describe("toPrecision", () => {
                 RangeError
             );
             expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
-                "Argument must be positive"
+                "digits must be non-negative"
             );
         });
         test("zero number of digits requested", () => {
@@ -117,7 +117,7 @@ describe("toPrecision", () => {
                 RangeError
             );
             expect(() => d.toPrecision({ digits: 0 }).toString()).toThrow(
-                "Argument must be positive"
+                "digits must be positive"
             );
         });
     });
@@ -333,5 +333,63 @@ describe("toPrecision", () => {
                 });
             });
         });
+    });
+});
+
+describe("roundingMode", () => {
+    test("default is halfEven", () => {
+        expect(new Decimal("1.25").toPrecision({ digits: 2 })).toStrictEqual(
+            "1.2"
+        );
+    });
+    test("halfExpand", () => {
+        expect(
+            new Decimal("1.25").toPrecision({
+                digits: 2,
+                roundingMode: "halfExpand",
+            })
+        ).toStrictEqual("1.3");
+    });
+    test("ceil on a positive value rounds up", () => {
+        expect(
+            new Decimal("1.21").toPrecision({
+                digits: 2,
+                roundingMode: "ceil",
+            })
+        ).toStrictEqual("1.3");
+    });
+    test("ceil on a negative value rounds toward zero", () => {
+        expect(
+            new Decimal("-1.29").toPrecision({
+                digits: 2,
+                roundingMode: "ceil",
+            })
+        ).toStrictEqual("-1.2");
+    });
+    test("floor on a negative value rounds away from zero", () => {
+        expect(
+            new Decimal("-1.21").toPrecision({
+                digits: 2,
+                roundingMode: "floor",
+            })
+        ).toStrictEqual("-1.3");
+    });
+    test("trunc", () => {
+        expect(
+            new Decimal("1.29").toPrecision({
+                digits: 2,
+                roundingMode: "trunc",
+            })
+        ).toStrictEqual("1.2");
+    });
+    test("invalid roundingMode throws RangeError", () => {
+        expect(() =>
+            new Decimal("1.25").toPrecision({ roundingMode: "bogus" })
+        ).toThrow(RangeError);
+    });
+    test("roundingMode alone leaves the value at natural precision", () => {
+        expect(
+            new Decimal("1.25").toPrecision({ roundingMode: "ceil" })
+        ).toStrictEqual("1.25");
     });
 });

--- a/tests/Decimal/toprecision.test.js
+++ b/tests/Decimal/toprecision.test.js
@@ -109,7 +109,7 @@ describe("toPrecision", () => {
                 RangeError
             );
             expect(() => d.toPrecision({ digits: -42 }).toString()).toThrow(
-                "digits must be non-negative"
+                "digits must be positive"
             );
         });
         test("zero number of digits requested", () => {

--- a/tests/Decimal/util.js
+++ b/tests/Decimal/util.js
@@ -5,3 +5,26 @@ export function expectDecimal128(a, b) {
     let rhs = b instanceof Decimal ? b.toString() : b;
     expect(lhs).toStrictEqual(rhs);
 }
+
+export function describeOptionsBagValidation(method, expected) {
+    describe("options bag validation", () => {
+        let a = new Decimal("1");
+        let b = new Decimal("2");
+        test("non-object options throws TypeError", () => {
+            expect(() => a[method](b, "ceil")).toThrow(TypeError);
+        });
+        test("non-string roundingMode throws TypeError", () => {
+            expect(() => a[method](b, { roundingMode: 42 })).toThrow(TypeError);
+        });
+        test("invalid roundingMode string throws RangeError", () => {
+            expect(() => a[method](b, { roundingMode: "bogus" })).toThrow(
+                RangeError
+            );
+        });
+        test("unknown keys are ignored", () => {
+            expect(a[method](b, { digits: 1 }).toString()).toStrictEqual(
+                expected
+            );
+        });
+    });
+}


### PR DESCRIPTION
Closes #40.

`round` now takes a single options bag `{ digits, roundingMode }`; positional arguments throw TypeError. `toFixed`, `toPrecision`, and `toExponential` accept the same bag, gaining `roundingMode` support (with directed modes flipped correctly for negative values). Omitted `digits` follows `Number.prototype` precedent, so a bare `toFixed()` now rounds to 0 fractional digits instead of echoing `toString()`, and `toExponential({ digits: 0 })` is now legal. `toFixed({ digits: Infinity })` now throws RangeError; use `toString()` or an explicit digit count for full expansions. The constructor and arithmetic methods now validate their options bags the same strict way (TypeError for non-object bags and non-string modes, RangeError for unrecognized modes) instead of silently ignoring malformed ones. Unknown bag keys are ignored, per platform convention.