### PR TITLE
Flip the magnitude comparison when comparing two negative values

### DIFF
--- a/src/CoefficientExponent.mts
+++ b/src/CoefficientExponent.mts
@@ -224,6 +224,11 @@ export class CoefficientExponent {
             return 1;
         }
 
+        if (this._isNegative) {
+            // Both negative: the larger magnitude is the smaller value.
+            return other.compareMagnitude(this);
+        }
+
         return this.compareMagnitude(other);
     }
 

--- a/tests/Decimal/compare.test.js
+++ b/tests/Decimal/compare.test.js
@@ -26,6 +26,23 @@ describe("compare", () => {
         let a = new Decimal("-123.456");
         expect(a.compare(a)).toStrictEqual(0);
     });
+    test("two distinct negative numbers", () => {
+        expect(new Decimal("-5").compare(new Decimal("-10"))).toStrictEqual(1);
+        expect(new Decimal("-10").compare(new Decimal("-5"))).toStrictEqual(-1);
+    });
+    test("two distinct negative numbers with different exponents", () => {
+        expect(new Decimal("-1.5").compare(new Decimal("-2.5"))).toStrictEqual(
+            1
+        );
+        expect(
+            new Decimal("-0.01").compare(new Decimal("-0.001"))
+        ).toStrictEqual(-1);
+    });
+    test("two distinct negative numbers at the bottom of the exponent range", () => {
+        expect(
+            new Decimal("-5e-324").compare(new Decimal("-1e-323"))
+        ).toStrictEqual(1);
+    });
     test("integer part is the same, decimal part is not", () => {
         let a = new Decimal("42.678");
         let b = new Decimal("42.6789");


### PR DESCRIPTION
Fixes #119.

`CoefficientExponent.cmp` now negates the magnitude comparison when both operands are negative. Regression tests cover distinct negative pairs with equal and differing exponents, including the counterexample pabst found at the bottom of the double range.

Unblocks the pabst CI step on #118.