### PR TITLE
Migrate from @jessealama/pabst to pabst-checker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "20260710.0.0",
             "license": "BSD-2-Clause",
             "devDependencies": {
-                "@jessealama/pabst": "^0.8.0",
                 "@stryker-mutator/core": "^9.6.1",
                 "bignumber.js": "^11.0.0",
                 "c8": "^11.0.0",
@@ -18,6 +17,7 @@
                 "http-server": "^14.1.1",
                 "jest": "^30.2.0",
                 "jest-light-runner": "^0.8.1",
+                "pabst-checker": "^0.12.0",
                 "prettier": "^3.4.1",
                 "typescript": "^7.0.2"
             }
@@ -1262,6 +1262,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-check": "^3.0.0 || ^4.0.0"
             },
@@ -1814,39 +1815,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@jessealama/pabst": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@jessealama/pabst/-/pabst-0.8.0.tgz",
-            "integrity": "sha512-F3E4rxhpOpFuBd4xrElKIo1zc67S6FIpyu9eHr7xPHa62vb8Qq/7QNF81w5b0Iqe29Gvo1a5+5F5+N2EJo+Y3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@fast-check/vitest": "^0.4.1",
-                "fast-check": "^4.8.0",
-                "typescript": "^6.0.3",
-                "vitest": "^4.1.9"
-            },
-            "bin": {
-                "pabst": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=24"
-            }
-        },
-        "node_modules/@jessealama/pabst/node_modules/typescript": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@jest/console": {
@@ -4624,9 +4592,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4806,9 +4774,9 @@
             }
         },
         "node_modules/fast-check": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-            "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+            "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
             "dev": true,
             "funding": [
                 {
@@ -4821,6 +4789,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pure-rand": "^8.0.0"
             },
@@ -4829,9 +4798,9 @@
             }
         },
         "node_modules/fast-check/node_modules/pure-rand": {
-            "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
-            "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+            "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
             "dev": true,
             "funding": [
                 {
@@ -4843,7 +4812,8 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -6738,9 +6708,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -6922,6 +6892,41 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pabst-checker": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/pabst-checker/-/pabst-checker-0.12.0.tgz",
+            "integrity": "sha512-L8Q5u+1dgLw4PRZvZ8sNFwk39thknpvKaxD6aquCafvlnnVs0iVLLk/14Ts3A5IrvaiKUYtRmJCAlG43jh/+HQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "typescript": "^6.0.3",
+                "vitest": "^4.1.9"
+            },
+            "bin": {
+                "pabst": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=24"
+            },
+            "peerDependencies": {
+                "@fast-check/vitest": "^0.4.1",
+                "fast-check": "^4.8.0"
+            }
+        },
+        "node_modules/pabst-checker/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -7138,9 +7143,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "dev": true,
             "funding": [
                 {
@@ -8173,16 +8178,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
+                "picomatch": "^4.0.5",
                 "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "rolldown": "~1.1.4",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     },
     "homepage": "https://github.com/jessealama/proposal-decimal-polyfill#readme",
     "devDependencies": {
-        "@jessealama/pabst": "^0.8.0",
         "@stryker-mutator/core": "^9.6.1",
         "bignumber.js": "^11.0.0",
         "c8": "^11.0.0",
@@ -66,6 +65,7 @@
         "http-server": "^14.1.1",
         "jest": "^30.2.0",
         "jest-light-runner": "^0.8.1",
+        "pabst-checker": "^0.12.0",
         "prettier": "^3.4.1",
         "typescript": "^7.0.2"
     }


### PR DESCRIPTION
Pabst has moved on npm: it's now published as `pabst-checker`, and `@jessealama/pabst` is deprecated. This swaps the devDependency to `pabst-checker@^0.12.0` (the only published version — there is no 0.11.0). The bin name is still `pabst`, so the `pabst test` npm script and the CI step need no changes.