### PR TITLE
Convert the stale benchmark example to TypeScript and run it in CI

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,4 +34,4 @@ jobs:
             - name: check coverage
               run: npx c8 check-coverage --lines 100 --functions 100 --branches 100 --statements 100
             - name: examples do not crash
-              run: for f in examples/*.ts; do node "$f" || (echo "'$f' crashed"; exit 1); done
+              run: for f in $(git ls-files 'examples/*.ts' 'examples/*.mts'); do node "$f" || (echo "'$f' crashed"; exit 1); done

--- a/examples/benchmark.ts
+++ b/examples/benchmark.ts
@@ -1,16 +1,15 @@
-import { Decimal } from "../src/Decimal128.mjs";
-import { BigNumber} from "bignumber.js";
-import pkg from 'decimal.js-light';
-const { Decimal } = pkg;
+import { Decimal } from "../src/Decimal.mjs";
+import { BigNumber } from "bignumber.js";
+import DecimalLight from "decimal.js-light";
 
 const numIterations = 100;
 const lotsOfNines = "9.999999999999999999999999999999999E-6143";
 const lotsOfThrees = "3.333333333333333333333333333333333E-6143";
 
-console.log("Decimal128");
+console.log("proposal-decimal");
 console.time();
 
-for (let i = 0; i < numIterations; i ++) {
+for (let i = 0; i < numIterations; i++) {
     let d = new Decimal(lotsOfNines);
     new Decimal(lotsOfThrees).divide(d).toString();
 }
@@ -19,7 +18,7 @@ console.timeEnd();
 
 console.log("BigNumber");
 console.time();
-for (let i = 0; i < numIterations; i ++) {
+for (let i = 0; i < numIterations; i++) {
     let d = new BigNumber(lotsOfNines);
     new BigNumber(lotsOfThrees).dividedBy(d).toString();
 }
@@ -28,9 +27,9 @@ console.timeEnd();
 
 console.log("decimal.js-light");
 console.time();
-for (let i = 0; i < numIterations; i ++) {
-    let d = new Decimal(lotsOfNines);
-    new Decimal(lotsOfThrees).dividedBy(d).toString();
+for (let i = 0; i < numIterations; i++) {
+    let d = new DecimalLight(lotsOfNines);
+    new DecimalLight(lotsOfThrees).dividedBy(d).toString();
 }
 
 console.timeEnd();


### PR DESCRIPTION
Fixes #111.

`benchmark.js` becomes `benchmark.ts`, matching the other examples: it now imports `../src/Decimal.mjs`, aliases decimal.js-light's export as `DecimalLight` to resolve the duplicate declaration, and gets type-checked by `tsc`. (The `bignumber.js` and `decimal.js-light` dependencies were already back in `package.json`, so no changes needed there.)

The CI examples step now iterates over `git ls-files 'examples/*.ts' 'examples/*.mts'` instead of the raw `examples/*.ts` glob. That picks up `floor.mts` and `pow.mts` (previously skipped) plus the new `benchmark.ts`, while keeping compiled artifacts out of the loop — a naive `*.mts` glob would match the `*.d.mts` files `tsc` emits earlier in the workflow, and executing those actually crashes node.